### PR TITLE
feat: bcrypt password hashing for Beauty auth

### DIFF
--- a/Backend/controller/main_frame_project/settings.py
+++ b/Backend/controller/main_frame_project/settings.py
@@ -94,6 +94,21 @@ DATABASES = {
 }
 
 
+# --- Password Hashing ---
+# BCryptSHA256PasswordHasher is the primary hasher.
+# SHA-256 pre-hashing removes bcrypt's 72-byte password length limit.
+# Django's make_password() and check_password() use this automatically,
+# so no changes are needed in models or views.
+# The fallback hashers allow existing PBKDF2 hashes to be verified
+# (e.g. any rows that existed before this change) and re-hashed to
+# bcrypt on next successful login.
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+]
+
+
 # --- Password Validation ---
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/Backend/controller/requirements.txt
+++ b/Backend/controller/requirements.txt
@@ -3,6 +3,7 @@ djangorestframework==3.15.2
 django-cors-headers==4.6.0
 psycopg2-binary==2.9.10
 gunicorn==23.0.0
+bcrypt==4.2.1
 pytest-django==4.9.0
 pytest==8.3.4
 playwright==1.49.1


### PR DESCRIPTION
## Summary
  Replaces Django's default PBKDF2 password hasher with **bcrypt** for all Beauty app password storage and authentication.

  ---

  ## What changed

  ### `Backend/controller/requirements.txt`
  - Added `bcrypt==4.2.1`

  ### `Backend/controller/main_frame_project/settings.py`
  ```python
  PASSWORD_HASHERS = [
      'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',  # primary
      'django.contrib.auth.hashers.PBKDF2PasswordHasher',        # fallback
      'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',    # fallback
  ]
  ```

  ---

  ## How it works
  Django's `make_password()` (called in `BeautyUser.set_password()` and `BusinessProvider.set_password()`) now produces bcrypt hashes automatically. Django's `check_password()` (called in `LoginView` and `BusinessLoginView`) authenticates against those hashes with no extra code changes needed.

  **BCryptSHA256PasswordHasher** is used (not the plain `BCryptPasswordHasher`) because bcrypt has a hard 72-byte input limit. SHA-256 pre-hashing means arbitrarily long passwords are handled correctly.

  ## Password field uniqueness
  | Field | Unique |
  |---|---|
  | `BeautyUser.email` | ✅ Yes |
  | `BeautyUser.password` | ❌ No |
  | `BusinessProvider.email` | ✅ Yes |
  | `BusinessProvider.password` | ❌ No |

  ## Backward compatibility
  PBKDF2 fallback hashers are kept in the list. Any existing rows hashed with PBKDF2 will continue to authenticate correctly via `check_password()`.

  ## Verified
  ```
  Hashed (stored in DB): bcrypt_sha256$$2b$12$... 
  Hasher used: bcrypt_sha256
  Correct password match: True
  Wrong password match:   False
  BeautyUser.password unique: False
  BeautyUser.email unique:    True
  ```