### PR TITLE
fix: add PostgreSQL service to docker-compose for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env and fill in the values before running docker compose up.
+# None of these values should be committed to version control.
+
+# --- Port Configuration ---
+BACKEND_PORT=8000
+FRONTEND_PORT=4200
+
+# --- PostgreSQL Database ---
+# These are used by both the db service and the backend service.
+# PGHOST and PGPORT default to the docker compose db service values.
+PGHOST=db
+PGPORT=5432
+PGDATABASE=pogoda_db
+PGUSER=pogoda_user
+PGPASSWORD=pogoda_pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,25 +6,48 @@
 # - Security: 0 vulnerabilities remaining
 
 services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=${PGDATABASE:-pogoda_db}
+      - POSTGRES_USER=${PGUSER:-pogoda_user}
+      - POSTGRES_PASSWORD=${PGPASSWORD:-pogoda_pass}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PGUSER:-pogoda_user} -d ${PGDATABASE:-pogoda_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   backend:
     build:
       context: ./Backend/controller
       dockerfile: Dockerfile
     working_dir: /app
     ports:
-      - "${BACKEND_PORT}:${BACKEND_PORT}"
+      - "${BACKEND_PORT:-8000}:${BACKEND_PORT:-8000}"
     volumes:
       - ./Backend/controller:/app
     environment:
       - PYTHONUNBUFFERED=1
-    command: ["python", "./manage.py", "runserver", "0.0.0.0:${BACKEND_PORT}"]
+      - PGHOST=${PGHOST:-db}
+      - PGPORT=${PGPORT:-5432}
+      - PGDATABASE=${PGDATABASE:-pogoda_db}
+      - PGUSER=${PGUSER:-pogoda_user}
+      - PGPASSWORD=${PGPASSWORD:-pogoda_pass}
+    command: ["python", "./manage.py", "runserver", "0.0.0.0:${BACKEND_PORT:-8000}"]
+    depends_on:
+      db:
+        condition: service_healthy
 
   frontend:
     build:
       context: ./Frontend/portfolioResume
       dockerfile: Dockerfile
     ports:
-      - "${FRONTEND_PORT}:${FRONTEND_PORT}"
+      - "${FRONTEND_PORT:-4200}:${FRONTEND_PORT:-4200}"
     volumes:
       - ./Frontend/portfolioResume:/app
     stdin_open: true
@@ -34,3 +57,6 @@ services:
       watch:
         - path: ../main_frame
           action: rebuild
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Problem

Running `docker compose up` locally caused the Django backend to crash immediately with:

```
psycopg2.OperationalError: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
```

The `docker-compose.yml` had no PostgreSQL service and passed no database connection environment variables to the backend container. Django fell back to a Unix socket connection which does not exist inside the container.

## Changes

### `docker-compose.yml`
- Added a `db` service using the official `postgres:16` image with a named volume (`postgres_data`) for data persistence
- Added a `pg_isready` health check so the backend waits until Postgres is fully ready before starting
- Added `depends_on: db: condition: service_healthy` to the backend service
- Passed all `PG*` variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) to the backend using `${VAR:-default}` syntax — overridable via a local `.env` file

### `.env.example` (new file)
- Documents all required local variables: `BACKEND_PORT`, `FRONTEND_PORT`, `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
- Safe placeholder values — `.env` is already in `.gitignore`

## How to run locally

```bash
cp .env.example .env
docker compose up --build
```

No Django settings or application logic were changed.