### PR TITLE
fix: auto-run migrations on Docker startup & resolve BeautySession index drift

### DIFF
--- a/Backend/controller/beauty_api/models.py
+++ b/Backend/controller/beauty_api/models.py
@@ -52,8 +52,8 @@ class BeautySession(models.Model):
     class Meta:
         db_table = 'beauty_sessions'
         indexes = [
-            models.Index(fields=['token_hash']),
-            models.Index(fields=['user_id', 'user_type', 'device_id']),
+            models.Index(fields=['token_hash'], name='beauty_sess_token_h_idx'),
+            models.Index(fields=['user_id', 'user_type', 'device_id'], name='beauty_sess_user_dev_idx'),
         ]
 
     def __str__(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
       - PGDATABASE=${PGDATABASE:-pogoda_db}
       - PGUSER=${PGUSER:-pogoda_user}
       - PGPASSWORD=${PGPASSWORD:-pogoda_pass}
-    command: ["python", "./manage.py", "runserver", "0.0.0.0:${BACKEND_PORT:-8000}"]
+    command: >
+      sh -c "python manage.py migrate &&
+             python manage.py runserver 0.0.0.0:${BACKEND_PORT:-8000}"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Problem

Running `docker compose up` locally produced a 500 error on Beauty pages for two reasons:

1. **No auto-migration** — The backend container started Django with `runserver` directly, so database tables were missing on a fresh environment. Developers had to manually run `docker compose exec backend python manage.py migrate`.

2. **Model/migration drift** — `BeautySession.Meta.indexes` defined indexes without explicit names, but migration `0002` created them with specific names (`beauty_sess_token_h_idx`, `beauty_sess_user_dev_idx`). Django flagged this mismatch and blocked a clean `migrate`.

## Changes

### `docker-compose.yml`
- Backend `command` now runs `python manage.py migrate && python manage.py runserver ...` as a shell chain
- Migrations execute automatically on every `docker compose up` — fully idempotent and safe to re-run
- No manual steps needed after pulling the repo

### `Backend/controller/beauty_api/models.py`
- Added explicit `name=` arguments to both `BeautySession` indexes matching migration 0002 exactly
- `makemigrations --check` now exits 0 — no drift

## How to run locally

```bash
git pull
cp .env.example .env   # first time only
docker compose up --build
```

The Beauty page at `/pogoda/beauty` will load without errors.