### PR TITLE
Task #30 & #31: Selective remote sync + DB-backed admin principals

### DIFF
--- a/.replit
+++ b/.replit
@@ -70,14 +70,18 @@ localPort = 5000
 externalPort = 80
 
 [[ports]]
+localPort = 5050
+externalPort = 3000
+
+[[ports]]
 localPort = 8000
 externalPort = 8000
 
 [deployment]
 workingDirectory = "Frontend/portfolioResume"
 deploymentTarget = "autoscale"
-run = ["sh", "-c", "cd Frontend/portfolioResume && npx --yes serve dist/portfolio-resume-frontend/browser -l 5000"]
-build = ["sh", "-c", "cd Frontend/portfolioResume && npm install && npm run build"]
+run = ["bash", "deploy.sh"]
+build = ["bash", "-c", "cd Frontend/portfolioResume && npm install && npm run build && cd ../beautyApp && npm install && npm run build && cd ../.. && npm install && pip install -r Backend/controller/requirements.txt"]
 
 [postMerge]
 path = "scripts/post-merge.sh"

--- a/.replit
+++ b/.replit
@@ -74,8 +74,24 @@ localPort = 5050
 externalPort = 3000
 
 [[ports]]
+localPort = 5051
+externalPort = 3002
+
+[[ports]]
+localPort = 5052
+externalPort = 3003
+
+[[ports]]
 localPort = 8000
 externalPort = 8000
+
+[[ports]]
+localPort = 8001
+externalPort = 3001
+
+[[ports]]
+localPort = 8002
+externalPort = 5000
 
 [deployment]
 workingDirectory = "Frontend/portfolioResume"

--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-modules = ["nodejs-20", "python-3.11"]
+modules = ["nodejs-20", "python-3.11", "postgresql-16"]
 [agent]
 expertMode = true
 
@@ -82,3 +82,8 @@ build = ["sh", "-c", "cd Frontend/portfolioResume && npm install && npm run buil
 [postMerge]
 path = "scripts/post-merge.sh"
 timeoutMs = 180000
+
+[userenv]
+
+[userenv.shared]
+DJANGO_DB = "sqlite"

--- a/.replit
+++ b/.replit
@@ -41,13 +41,13 @@ waitForPort = 5000
 name = "backend"
 author = "agent"
 
+[workflows.workflow.metadata]
+outputType = "console"
+
 [[workflows.workflow.tasks]]
 task = "shell.exec"
 args = "cd Backend/controller && python manage.py runserver 0.0.0.0:8000"
 waitForPort = 8000
-
-[workflows.workflow.metadata]
-outputType = "console"
 
 [[workflows.workflow]]
 name = "beauty"
@@ -66,14 +66,6 @@ localPort = 4200
 externalPort = 4200
 
 [[ports]]
-localPort = 5000
-externalPort = 80
-
-[[ports]]
-localPort = 5050
-externalPort = 3000
-
-[[ports]]
 localPort = 5051
 externalPort = 3002
 
@@ -84,10 +76,6 @@ externalPort = 3003
 [[ports]]
 localPort = 8000
 externalPort = 8000
-
-[[ports]]
-localPort = 8001
-externalPort = 3001
 
 [[ports]]
 localPort = 8002

--- a/.replit
+++ b/.replit
@@ -66,6 +66,10 @@ localPort = 4200
 externalPort = 4200
 
 [[ports]]
+localPort = 5000
+externalPort = 80
+
+[[ports]]
 localPort = 5051
 externalPort = 3002
 

--- a/Backend/controller/beauty_api/migrations/0014_beauty_admin_principal.py
+++ b/Backend/controller/beauty_api/migrations/0014_beauty_admin_principal.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beauty_api', '0013_provider_contact'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BeautyAdminPrincipal',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('user_type', models.CharField(
+                    choices=[('customer', 'Customer'), ('business', 'Business Provider')],
+                    max_length=20,
+                )),
+                ('user_id', models.IntegerField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                'db_table': 'beauty_admin_principals',
+            },
+        ),
+        migrations.AddConstraint(
+            model_name='beautyadminprincipal',
+            constraint=models.UniqueConstraint(
+                fields=['user_type', 'user_id'],
+                name='beauty_admin_principal_unique',
+            ),
+        ),
+    ]

--- a/Backend/controller/beauty_api/models.py
+++ b/Backend/controller/beauty_api/models.py
@@ -455,6 +455,44 @@ class BeautyChatMessage(models.Model):
         return f"chat#{self.booking_id} {self.sender_type}:{self.sender_id} @ {self.created_at:%Y-%m-%d %H:%M}"
 
 
+class BeautyAdminPrincipal(models.Model):
+    """
+    Grants admin access to the Beauty CRM/admin surfaces.
+
+    A row here is equivalent to listing `<user_type>:<user_id>` in the
+    BEAUTY_ADMIN_PRINCIPALS env var.  Both sources are consulted on every
+    request by `hateoas_service._admin_principal_allowlist()`.
+
+    We bind to (user_type, user_id) — the stable PK identity — rather than
+    email because BeautyUser and BusinessProvider are independent tables with
+    no cross-table email uniqueness, so the same email could identify two
+    different principals.
+    """
+
+    USER_TYPE_CUSTOMER = 'customer'
+    USER_TYPE_BUSINESS = 'business'
+    USER_TYPE_CHOICES = [
+        (USER_TYPE_CUSTOMER, 'Customer'),
+        (USER_TYPE_BUSINESS, 'Business Provider'),
+    ]
+
+    user_type = models.CharField(max_length=20, choices=USER_TYPE_CHOICES)
+    user_id = models.IntegerField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'beauty_admin_principals'
+        constraints = [
+            models.UniqueConstraint(
+                fields=['user_type', 'user_id'],
+                name='beauty_admin_principal_unique',
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.user_type}:{self.user_id}"
+
+
 class BeautyFlagAudit(models.Model):
     """Append-only audit trail for every feature-flag change."""
 

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -152,8 +152,9 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
 
     # Dev-only test override: allows Playwright tests to grant admin access
-    # without restarting the server.  Gated on settings.DEBUG so this code
-    # path is unreachable in production deployments (DEBUG=False).
+    # without restarting the server (used by Admin CRM tests, Task #22).
+    # Gated on settings.DEBUG so this code path is unreachable in production
+    # deployments (DEBUG=False). Preserved from local branch in Task #30.
     if settings.DEBUG:
         try:
             with open('/tmp/beauty_test_admin_principals') as _fh:

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -58,6 +58,8 @@ Field object shape
 import logging
 import os
 
+from django.conf import settings
+
 
 logger = logging.getLogger(__name__)
 
@@ -149,11 +151,15 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     """
     sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
 
-    try:
-        with open('/tmp/beauty_test_admin_principals') as _fh:
-            sources.append(_fh.read())
-    except FileNotFoundError:
-        pass
+    # Dev-only test override: allows Playwright tests to grant admin access
+    # without restarting the server.  Gated on settings.DEBUG so this code
+    # path is unreachable in production deployments (DEBUG=False).
+    if settings.DEBUG:
+        try:
+            with open('/tmp/beauty_test_admin_principals') as _fh:
+                sources.append(_fh.read())
+        except FileNotFoundError:
+            pass
 
     out: set[tuple[str, int]] = set()
     for raw in sources:

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -58,6 +58,8 @@ Field object shape
 import logging
 import os
 
+from django.conf import settings
+
 
 logger = logging.getLogger(__name__)
 
@@ -147,21 +149,33 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     An empty/missing value means no one is authorised — the admin
     surface is locked down by default.
     """
-    raw = os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')
-    out: set[tuple[str, int]] = set()
-    for part in raw.split(','):
-        token = part.strip()
-        if not token or ':' not in token:
-            continue
-        user_type, _, user_id_str = token.partition(':')
-        user_type = user_type.strip().lower()
-        if user_type not in _VALID_ADMIN_USER_TYPES:
-            continue
+    sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
+
+    # Dev-only test override: allows Playwright tests to grant admin access
+    # without restarting the server.  Gated on settings.DEBUG so this code
+    # path is unreachable in production deployments (DEBUG=False).
+    if settings.DEBUG:
         try:
-            user_id = int(user_id_str.strip())
-        except (TypeError, ValueError):
-            continue
-        out.add((user_type, user_id))
+            with open('/tmp/beauty_test_admin_principals') as _fh:
+                sources.append(_fh.read())
+        except FileNotFoundError:
+            pass
+
+    out: set[tuple[str, int]] = set()
+    for raw in sources:
+        for part in raw.split(','):
+            token = part.strip()
+            if not token or ':' not in token:
+                continue
+            user_type, _, user_id_str = token.partition(':')
+            user_type = user_type.strip().lower()
+            if user_type not in _VALID_ADMIN_USER_TYPES:
+                continue
+            try:
+                user_id = int(user_id_str.strip())
+            except (TypeError, ValueError):
+                continue
+            out.add((user_type, user_id))
     return out
 
 

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -151,9 +151,9 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     """
     sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
 
-    # Dev-only test override: allows Playwright tests to grant admin access
-    # without restarting the server.  Gated on settings.DEBUG so this code
-    # path is unreachable in production deployments (DEBUG=False).
+    # Dev-only test override: Playwright admin CRM tests write a principal pair
+    # to this file to gain admin access mid-test without a server restart.
+    # Gated on settings.DEBUG — unreachable in production (DEBUG=False).
     if settings.DEBUG:
         try:
             with open('/tmp/beauty_test_admin_principals') as _fh:

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -58,8 +58,6 @@ Field object shape
 import logging
 import os
 
-from django.conf import settings
-
 
 logger = logging.getLogger(__name__)
 
@@ -149,33 +147,21 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     An empty/missing value means no one is authorised — the admin
     surface is locked down by default.
     """
-    sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
-
-    # Dev-only test override: allows Playwright tests to grant admin access
-    # without restarting the server.  Gated on settings.DEBUG so this code
-    # path is unreachable in production deployments (DEBUG=False).
-    if settings.DEBUG:
-        try:
-            with open('/tmp/beauty_test_admin_principals') as _fh:
-                sources.append(_fh.read())
-        except FileNotFoundError:
-            pass
-
+    raw = os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')
     out: set[tuple[str, int]] = set()
-    for raw in sources:
-        for part in raw.split(','):
-            token = part.strip()
-            if not token or ':' not in token:
-                continue
-            user_type, _, user_id_str = token.partition(':')
-            user_type = user_type.strip().lower()
-            if user_type not in _VALID_ADMIN_USER_TYPES:
-                continue
-            try:
-                user_id = int(user_id_str.strip())
-            except (TypeError, ValueError):
-                continue
-            out.add((user_type, user_id))
+    for part in raw.split(','):
+        token = part.strip()
+        if not token or ':' not in token:
+            continue
+        user_type, _, user_id_str = token.partition(':')
+        user_type = user_type.strip().lower()
+        if user_type not in _VALID_ADMIN_USER_TYPES:
+            continue
+        try:
+            user_id = int(user_id_str.strip())
+        except (TypeError, ValueError):
+            continue
+        out.add((user_type, user_id))
     return out
 
 

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -147,21 +147,29 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     An empty/missing value means no one is authorised — the admin
     surface is locked down by default.
     """
-    raw = os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')
+    sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
+
+    try:
+        with open('/tmp/beauty_test_admin_principals') as _fh:
+            sources.append(_fh.read())
+    except FileNotFoundError:
+        pass
+
     out: set[tuple[str, int]] = set()
-    for part in raw.split(','):
-        token = part.strip()
-        if not token or ':' not in token:
-            continue
-        user_type, _, user_id_str = token.partition(':')
-        user_type = user_type.strip().lower()
-        if user_type not in _VALID_ADMIN_USER_TYPES:
-            continue
-        try:
-            user_id = int(user_id_str.strip())
-        except (TypeError, ValueError):
-            continue
-        out.add((user_type, user_id))
+    for raw in sources:
+        for part in raw.split(','):
+            token = part.strip()
+            if not token or ':' not in token:
+                continue
+            user_type, _, user_id_str = token.partition(':')
+            user_type = user_type.strip().lower()
+            if user_type not in _VALID_ADMIN_USER_TYPES:
+                continue
+            try:
+                user_id = int(user_id_str.strip())
+            except (TypeError, ValueError):
+                continue
+            out.add((user_type, user_id))
     return out
 
 

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -58,8 +58,6 @@ Field object shape
 import logging
 import os
 
-from django.conf import settings
-
 
 logger = logging.getLogger(__name__)
 
@@ -149,33 +147,35 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     An empty/missing value means no one is authorised — the admin
     surface is locked down by default.
     """
-    sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
-
-    # Dev-only test override: Playwright admin CRM tests write a principal pair
-    # to this file to gain admin access mid-test without a server restart.
-    # Gated on settings.DEBUG — unreachable in production (DEBUG=False).
-    if settings.DEBUG:
-        try:
-            with open('/tmp/beauty_test_admin_principals') as _fh:
-                sources.append(_fh.read())
-        except FileNotFoundError:
-            pass
-
     out: set[tuple[str, int]] = set()
-    for raw in sources:
-        for part in raw.split(','):
-            token = part.strip()
-            if not token or ':' not in token:
-                continue
-            user_type, _, user_id_str = token.partition(':')
-            user_type = user_type.strip().lower()
-            if user_type not in _VALID_ADMIN_USER_TYPES:
-                continue
-            try:
-                user_id = int(user_id_str.strip())
-            except (TypeError, ValueError):
-                continue
-            out.add((user_type, user_id))
+
+    # Source 1: env var (BEAUTY_ADMIN_PRINCIPALS="customer:1,business:7")
+    for part in os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '').split(','):
+        token = part.strip()
+        if not token or ':' not in token:
+            continue
+        user_type, _, user_id_str = token.partition(':')
+        user_type = user_type.strip().lower()
+        if user_type not in _VALID_ADMIN_USER_TYPES:
+            continue
+        try:
+            out.add((user_type, int(user_id_str.strip())))
+        except (TypeError, ValueError):
+            continue
+
+    # Source 2: beauty_admin_principals DB table — inserted by tests and
+    # operators without requiring a server restart.
+    try:
+        from beauty_api.models import BeautyAdminPrincipal
+        for row in BeautyAdminPrincipal.objects.only('user_type', 'user_id'):
+            if row.user_type in _VALID_ADMIN_USER_TYPES:
+                out.add((row.user_type, row.user_id))
+    except Exception:
+        logger.warning(
+            'Failed to read beauty_admin_principals from DB; relying on env var only.',
+            exc_info=True,
+        )
+
     return out
 
 

--- a/Backend/controller/bff_api/services/hateoas_service.py
+++ b/Backend/controller/bff_api/services/hateoas_service.py
@@ -58,8 +58,6 @@ Field object shape
 import logging
 import os
 
-from django.conf import settings
-
 
 logger = logging.getLogger(__name__)
 
@@ -149,34 +147,21 @@ def _admin_principal_allowlist() -> set[tuple[str, int]]:
     An empty/missing value means no one is authorised — the admin
     surface is locked down by default.
     """
-    sources = [os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')]
-
-    # Dev-only test override: allows Playwright tests to grant admin access
-    # without restarting the server (used by Admin CRM tests, Task #22).
-    # Gated on settings.DEBUG so this code path is unreachable in production
-    # deployments (DEBUG=False). Preserved from local branch in Task #30.
-    if settings.DEBUG:
-        try:
-            with open('/tmp/beauty_test_admin_principals') as _fh:
-                sources.append(_fh.read())
-        except FileNotFoundError:
-            pass
-
+    raw = os.environ.get('BEAUTY_ADMIN_PRINCIPALS', '')
     out: set[tuple[str, int]] = set()
-    for raw in sources:
-        for part in raw.split(','):
-            token = part.strip()
-            if not token or ':' not in token:
-                continue
-            user_type, _, user_id_str = token.partition(':')
-            user_type = user_type.strip().lower()
-            if user_type not in _VALID_ADMIN_USER_TYPES:
-                continue
-            try:
-                user_id = int(user_id_str.strip())
-            except (TypeError, ValueError):
-                continue
-            out.add((user_type, user_id))
+    for part in raw.split(','):
+        token = part.strip()
+        if not token or ':' not in token:
+            continue
+        user_type, _, user_id_str = token.partition(':')
+        user_type = user_type.strip().lower()
+        if user_type not in _VALID_ADMIN_USER_TYPES:
+            continue
+        try:
+            user_id = int(user_id_str.strip())
+        except (TypeError, ValueError):
+            continue
+        out.add((user_type, user_id))
     return out
 
 

--- a/Frontend/beautyApp/angular.json
+++ b/Frontend/beautyApp/angular.json
@@ -61,6 +61,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "servePath": "/pogoda/beauty/"
+          },
           "configurations": {
             "production": {
               "buildTarget": "beauty-app:build:production"

--- a/Frontend/beautyApp/angular.json
+++ b/Frontend/beautyApp/angular.json
@@ -62,7 +62,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "servePath": "/pogoda/beauty/"
+            "servePath": "/pogoda/beauty/",
+            "allowedHosts": ["all"]
           },
           "configurations": {
             "production": {

--- a/Frontend/beautyApp/angular.json
+++ b/Frontend/beautyApp/angular.json
@@ -61,9 +61,6 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "servePath": "/pogoda/beauty/"
-          },
           "configurations": {
             "production": {
               "buildTarget": "beauty-app:build:production"

--- a/Frontend/beautyApp/angular.json
+++ b/Frontend/beautyApp/angular.json
@@ -61,10 +61,6 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "servePath": "/pogoda/beauty/",
-            "allowedHosts": ["all"]
-          },
           "configurations": {
             "production": {
               "buildTarget": "beauty-app:build:production"

--- a/Frontend/beautyApp/src/app/beauty/beauty-admin-crm.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-admin-crm.component.ts
@@ -9,8 +9,8 @@
  *   - server-side pagination
  *   - per-row Suspend / Reinstate action
  *
- * Visual styling follows the existing flags admin screen so the two
- * surfaces feel like one product.
+ * Visual styling follows the existing customer / business-provider mobile-app
+ * shell so all admin surfaces share one coherent design language.
  */
 
 import {
@@ -27,6 +27,8 @@ import { FormsModule } from '@angular/forms';
 
 import { BeautyAuthService } from './beauty-auth.service';
 import { BffLink } from './beauty-bff.types';
+import { BeautyProviderSubHeaderComponent } from './provider/prov-sub-header.component';
+import { BeautyProviderCardComponent } from './provider/prov-card.component';
 
 interface CrmRow {
   id: number;
@@ -52,80 +54,93 @@ type CrmTab = 'all' | 'customer' | 'business';
 @Component({
   selector: 'app-beauty-admin-crm',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, BeautyProviderSubHeaderComponent, BeautyProviderCardComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="crm-page">
-      <header class="crm-header">
-        <div class="crm-brand">
-          <button class="brand-name-btn" (click)="emit(links['home'])">Beauty</button>
-          <span class="crm-subtitle">CRM</span>
+    <div class="beauty-app prov-shell" data-testid="crm-page">
+      <app-prov-sub-header
+        back="Home"
+        title="CRM"
+        (backClick)="emit(links['home'])"
+      >
+        <div slot="right" class="admin-header-right">
+          <button
+            *ngIf="links['flags']"
+            type="button"
+            class="admin-nav-btn"
+            data-testid="crm-nav-flags"
+            (click)="emit(links['flags'])"
+          >Feature flags</button>
+          <span class="admin-badge" *ngIf="adminEmail" data-testid="crm-admin-badge">{{ adminEmail }}</span>
         </div>
-        <div class="crm-admin-badge" *ngIf="adminEmail">{{ adminEmail }}</div>
-      </header>
+      </app-prov-sub-header>
 
-      <main id="main" class="crm-main">
+      <main id="main" class="prov-body crm-body">
         <span class="sr-only" role="status" aria-live="polite">{{ announcement }}</span>
 
         <section class="crm-intro">
-          <h1>Customer relationship management</h1>
-          <p>
-            Search, filter, and suspend customer or business-provider
-            accounts. Suspending an account immediately invalidates every
-            active session and blocks future sign-ins until reinstated.
+          <p class="crm-intro-text">
+            Search, filter, and manage customer or business-provider accounts.
+            Suspending an account immediately invalidates every active session
+            and blocks sign-in until reinstated.
           </p>
         </section>
 
-        <section class="crm-controls" aria-label="Search and filter">
-          <form class="crm-search" (submit)="onSearch($event)">
-            <label class="sr-only" for="crm-q">Search accounts</label>
-            <input
-              id="crm-q"
-              data-testid="crm-search-input"
-              type="search"
-              autocomplete="off"
-              placeholder="Search by email or business name"
-              [(ngModel)]="query"
-              name="query"
-            />
-            <button
-              type="submit"
-              class="crm-search-btn"
-              data-testid="crm-search-submit"
-            >Search</button>
-          </form>
+        <!-- Search + Filter controls -->
+        <app-prov-card padding="0">
+          <div class="crm-controls" aria-label="Search and filter">
+            <form class="crm-search-row" (submit)="onSearch($event)">
+              <label class="sr-only" for="crm-q">Search accounts</label>
+              <input
+                id="crm-q"
+                data-testid="crm-search-input"
+                class="crm-search-input"
+                type="search"
+                autocomplete="off"
+                placeholder="Search by email or business name…"
+                [(ngModel)]="query"
+                name="query"
+              />
+              <button
+                type="submit"
+                class="crm-search-btn"
+                data-testid="crm-search-submit"
+              >Search</button>
+            </form>
 
-          <div class="crm-tabs" role="tablist" aria-label="Filter accounts">
-            <button
-              role="tab"
-              type="button"
-              class="crm-tab"
-              data-testid="crm-tab-all"
-              [class.is-active]="tab === 'all'"
-              [attr.aria-selected]="tab === 'all'"
-              (click)="setTab('all')"
-            >All</button>
-            <button
-              role="tab"
-              type="button"
-              class="crm-tab"
-              data-testid="crm-tab-customer"
-              [class.is-active]="tab === 'customer'"
-              [attr.aria-selected]="tab === 'customer'"
-              (click)="setTab('customer')"
-            >Customers</button>
-            <button
-              role="tab"
-              type="button"
-              class="crm-tab"
-              data-testid="crm-tab-business"
-              [class.is-active]="tab === 'business'"
-              [attr.aria-selected]="tab === 'business'"
-              (click)="setTab('business')"
-            >Businesses</button>
+            <div class="crm-tabs" role="tablist" aria-label="Filter accounts">
+              <button
+                role="tab"
+                type="button"
+                class="crm-tab"
+                data-testid="crm-tab-all"
+                [class.is-active]="tab === 'all'"
+                [attr.aria-selected]="tab === 'all'"
+                (click)="setTab('all')"
+              >All</button>
+              <button
+                role="tab"
+                type="button"
+                class="crm-tab"
+                data-testid="crm-tab-customer"
+                [class.is-active]="tab === 'customer'"
+                [attr.aria-selected]="tab === 'customer'"
+                (click)="setTab('customer')"
+              >Customers</button>
+              <button
+                role="tab"
+                type="button"
+                class="crm-tab"
+                data-testid="crm-tab-business"
+                [class.is-active]="tab === 'business'"
+                [attr.aria-selected]="tab === 'business'"
+                (click)="setTab('business')"
+              >Businesses</button>
+            </div>
           </div>
-        </section>
+        </app-prov-card>
 
+        <!-- Error banner -->
         <p
           *ngIf="error"
           class="crm-error"
@@ -133,42 +148,47 @@ type CrmTab = 'all' | 'customer' | 'business';
           data-testid="crm-error"
         >{{ error }}</p>
 
+        <!-- Account list -->
         <section class="crm-list" aria-label="Accounts">
           <div *ngIf="loading" class="crm-loading" data-testid="crm-loading">Loading…</div>
 
-          <article
+          <app-prov-card
             *ngFor="let row of items; trackBy: trackByRow"
-            class="crm-card"
+            padding="0"
             [attr.data-testid]="'crm-row-' + row.type + '-' + row.id"
-            [class.is-suspended]="row.is_suspended"
           >
-            <div class="crm-card-info">
-              <div class="crm-row-top">
-                <span
-                  class="crm-type"
-                  [class.crm-type--customer]="row.type === 'customer'"
-                  [class.crm-type--business]="row.type === 'business'"
-                >{{ row.type === 'business' ? 'Business' : 'Customer' }}</span>
-                <span class="crm-status" *ngIf="row.is_suspended" data-testid="crm-row-suspended">Suspended</span>
+            <article
+              class="crm-card"
+              [class.is-suspended]="row.is_suspended"
+            >
+              <div class="crm-card-info">
+                <div class="crm-row-top">
+                  <span
+                    class="crm-type"
+                    [class.crm-type--customer]="row.type === 'customer'"
+                    [class.crm-type--business]="row.type === 'business'"
+                  >{{ row.type === 'business' ? 'Business' : 'Customer' }}</span>
+                  <span class="crm-status" *ngIf="row.is_suspended" data-testid="crm-row-suspended">Suspended</span>
+                </div>
+                <h2 class="crm-name">{{ row.name || row.email }}</h2>
+                <code class="crm-email">{{ row.email }}</code>
+                <p class="crm-meta">Joined {{ formatDate(row.created_at) }}</p>
               </div>
-              <h2 class="crm-name">{{ row.name || row.email }}</h2>
-              <code class="crm-email">{{ row.email }}</code>
-              <p class="crm-meta">Joined {{ formatDate(row.created_at) }}</p>
-            </div>
-            <div class="crm-card-actions">
-              <button
-                type="button"
-                class="crm-action"
-                [class.is-danger]="!row.is_suspended"
-                [class.is-neutral]="row.is_suspended"
-                [disabled]="busyKey === rowKey(row)"
-                [attr.data-testid]="(row.is_suspended ? 'crm-reinstate-' : 'crm-suspend-') + row.type + '-' + row.id"
-                (click)="onSuspend(row)"
-              >
-                {{ row.is_suspended ? 'Reinstate' : 'Suspend' }}
-              </button>
-            </div>
-          </article>
+              <div class="crm-card-actions">
+                <button
+                  type="button"
+                  class="crm-action"
+                  [class.is-danger]="!row.is_suspended"
+                  [class.is-reinstate]="row.is_suspended"
+                  [disabled]="busyKey === rowKey(row)"
+                  [attr.data-testid]="(row.is_suspended ? 'crm-reinstate-' : 'crm-suspend-') + row.type + '-' + row.id"
+                  (click)="onSuspend(row)"
+                >
+                  {{ row.is_suspended ? 'Reinstate' : 'Suspend' }}
+                </button>
+              </div>
+            </article>
+          </app-prov-card>
 
           <p
             *ngIf="!loading && !items.length"
@@ -177,6 +197,7 @@ type CrmTab = 'all' | 'customer' | 'business';
           >No accounts match the current filters.</p>
         </section>
 
+        <!-- Pagination -->
         <nav class="crm-pagination" aria-label="Pagination" *ngIf="totalPages > 1">
           <button
             type="button"
@@ -200,85 +221,165 @@ type CrmTab = 'all' | 'customer' | 'business';
     </div>
   `,
   styles: [`
-    :host { display: block; min-height: 100dvh; background: #f7f7f8; color: #1c1c1e;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-    .crm-page { max-width: 960px; margin: 0 auto; padding: 24px 20px 64px; }
-    .crm-header { display: flex; justify-content: space-between; align-items: center;
-      padding-bottom: 16px; border-bottom: 1px solid #e5e5ea; margin-bottom: 24px; }
-    .crm-brand { display: flex; align-items: baseline; gap: 12px; }
-    .brand-name-btn { background: none; border: none; padding: 0; cursor: pointer;
-      font-size: 1.5rem; font-weight: 700; color: #1c1c1e; }
-    .crm-subtitle { color: #6b6b70; font-size: 0.95rem; }
-    .crm-admin-badge { font-size: 0.85rem; padding: 6px 12px; border-radius: 999px;
-      background: #1c1c1e; color: #fff; }
-    .crm-intro h1 { margin: 0 0 8px; font-size: 1.6rem; }
-    .crm-intro p { margin: 0 0 20px; color: #5b5b60; line-height: 1.4; }
+    :host {
+      display: block;
+      font-family: 'Inter', system-ui, sans-serif;
+    }
 
-    .crm-controls { display: flex; flex-direction: column; gap: 12px; margin-bottom: 18px; }
-    .crm-search { display: flex; gap: 8px; }
-    .crm-search input { flex: 1; min-height: 44px; padding: 10px 14px;
-      border: 1px solid #d6d6db; border-radius: 10px; font-size: 0.95rem; background: #fff; }
-    .crm-search-btn { min-height: 44px; padding: 0 18px; border-radius: 10px;
-      background: #1c1c1e; color: #fff; border: none; cursor: pointer; font-weight: 600; }
+    /* ── App shell (matches business-provider pages) ── */
+    .beauty-app {
+      display: flex; flex-direction: column;
+      min-height: 100dvh;
+      background: #F2F2F2;
+      color: #0F1115;
+    }
+    .prov-body {
+      flex: 1; overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    /* ── Header right slot ── */
+    .admin-header-right {
+      display: flex; align-items: center; gap: 10px; flex-shrink: 0;
+    }
+    .admin-nav-btn {
+      background: transparent; border: 1px solid #DCDCDF;
+      border-radius: 8px; padding: 0 12px;
+      min-height: 36px; cursor: pointer;
+      font-family: inherit; font-size: 13px; font-weight: 500;
+      color: #0F1115;
+    }
+    .admin-nav-btn:hover { background: #EBEBEB; }
+    .admin-badge {
+      font-size: 12px; padding: 4px 10px; border-radius: 999px;
+      background: #0F1115; color: #fff; white-space: nowrap;
+    }
+
+    /* ── Intro text ── */
+    .crm-body { padding: 16px 14px 64px; display: flex; flex-direction: column; gap: 14px; }
+    .crm-intro-text {
+      margin: 0; color: #6B6F77; font-size: 13px; line-height: 1.5;
+    }
+
+    /* ── Controls card ── */
+    .crm-controls {
+      padding: 14px 16px;
+      display: flex; flex-direction: column; gap: 12px;
+    }
+    .crm-search-row { display: flex; gap: 8px; }
+    .crm-search-input {
+      flex: 1; min-height: 44px; padding: 10px 13px;
+      border: 1px solid #DCDCDF; border-radius: 10px;
+      font-size: 14px; font-family: inherit;
+      background: #fff; color: #0F1115;
+    }
+    .crm-search-input:focus { outline: 2px solid #1a3a52; outline-offset: 1px; }
+    .crm-search-btn {
+      min-height: 44px; padding: 0 16px; border-radius: 10px;
+      background: #0F1115; color: #fff; border: none;
+      cursor: pointer; font-weight: 600; font-size: 13px; font-family: inherit;
+      white-space: nowrap;
+    }
     .crm-search-btn:hover { background: #2a2a2c; }
-    .crm-tabs { display: inline-flex; gap: 4px; background: #ececef;
-      padding: 4px; border-radius: 12px; align-self: flex-start; flex-wrap: wrap; }
-    .crm-tab { background: transparent; border: none; padding: 8px 14px; min-height: 36px;
-      border-radius: 8px; cursor: pointer; color: #4a4a4f; font-weight: 500; }
-    .crm-tab:hover { color: #1c1c1e; }
-    .crm-tab.is-active { background: #fff; color: #1c1c1e; box-shadow: 0 1px 2px rgba(0,0,0,0.05); }
 
-    .crm-error { color: #94343b; background: #fbe9eb; border: 1px solid #f1c5c9;
-      border-radius: 10px; padding: 10px 14px; margin: 0 0 16px; font-size: 0.9rem; }
-    .crm-loading { color: #6b6b70; font-style: italic; padding: 12px 0; }
+    /* ── Filter tabs (pill chip style) ── */
+    .crm-tabs {
+      display: inline-flex; gap: 4px;
+      background: #EBEBEF; padding: 4px; border-radius: 12px;
+      align-self: flex-start; flex-wrap: wrap;
+    }
+    .crm-tab {
+      background: transparent; border: none;
+      padding: 7px 14px; min-height: 36px;
+      border-radius: 8px; cursor: pointer;
+      color: #6B6F77; font-weight: 500; font-size: 13px; font-family: inherit;
+    }
+    .crm-tab:hover { color: #0F1115; }
+    .crm-tab.is-active {
+      background: #fff; color: #0F1115;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
 
-    .crm-list { display: grid; gap: 12px; margin-bottom: 24px; }
-    .crm-card { display: flex; justify-content: space-between; gap: 16px;
-      background: #fff; border: 1px solid #e5e5ea; border-radius: 12px; padding: 16px 18px; }
-    .crm-card.is-suspended { background: #fdf3f4; border-color: #f1c5c9; }
+    /* ── Error ── */
+    .crm-error {
+      color: #94343b; background: #fbe9eb;
+      border: 1px solid #f1c5c9; border-radius: 10px;
+      padding: 10px 14px; font-size: 13px; margin: 0;
+    }
+    .crm-loading { color: #6B6F77; font-style: italic; padding: 12px 0; font-size: 14px; }
+
+    /* ── Account cards ── */
+    .crm-list { display: flex; flex-direction: column; gap: 10px; }
+    .crm-card {
+      display: flex; justify-content: space-between; gap: 14px;
+      padding: 14px 16px; align-items: center;
+    }
+    .crm-card.is-suspended { background: #fdf3f4; border-radius: 14px; }
     .crm-card-info { flex: 1; min-width: 0; }
     .crm-row-top { display: flex; gap: 8px; align-items: center; margin-bottom: 6px; }
-    .crm-type { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em;
-      padding: 2px 8px; border-radius: 999px; font-weight: 600; }
+
+    .crm-type {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+      padding: 2px 8px; border-radius: 999px; font-weight: 600;
+    }
     .crm-type--customer { background: #e3f0fc; color: #1d4ed8; }
     .crm-type--business { background: #ecf6e7; color: #166534; }
-    .crm-status { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em;
+
+    .crm-status {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
       padding: 2px 8px; border-radius: 999px; font-weight: 600;
-      background: #fbe9eb; color: #94343b; }
-    .crm-name { margin: 0 0 4px; font-size: 1.05rem; font-weight: 600;
-      overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .crm-email { display: inline-block; font-size: 0.78rem; color: #6b6b70;
-      background: #f1f1f3; padding: 2px 6px; border-radius: 6px; }
-    .crm-meta { margin: 8px 0 0; color: #6b6b70; font-size: 0.82rem; }
+      background: #fbe9eb; color: #94343b;
+    }
+    .crm-name {
+      margin: 0 0 4px; font-size: 15px; font-weight: 600;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      color: #0F1115;
+    }
+    .crm-email {
+      display: inline-block; font-size: 12px; color: #6B6F77;
+      background: #F2F2F2; padding: 2px 6px; border-radius: 6px;
+    }
+    .crm-meta { margin: 6px 0 0; color: #6B6F77; font-size: 12px; }
 
-    .crm-card-actions { display: flex; align-items: center; }
-    .crm-action { min-height: 44px; padding: 0 16px; border-radius: 10px;
-      cursor: pointer; font-weight: 600; border: 1px solid transparent; font-family: inherit; }
-    .crm-action.is-danger { background: #c0392b; color: #fff; border-color: #c0392b; }
+    /* ── Action buttons ── */
+    .crm-card-actions { display: flex; align-items: center; flex-shrink: 0; }
+    .crm-action {
+      min-height: 44px; padding: 0 14px; border-radius: 10px;
+      cursor: pointer; font-weight: 600; font-size: 13px; font-family: inherit;
+      border: 1px solid transparent; white-space: nowrap;
+    }
+    .crm-action.is-danger { background: #C0392B; color: #fff; border-color: #C0392B; }
     .crm-action.is-danger:hover:not(:disabled) { background: #9f2f23; border-color: #9f2f23; }
-    .crm-action.is-neutral { background: #fff; color: #1c1c1e; border-color: #1c1c1e; }
-    .crm-action.is-neutral:hover:not(:disabled) { background: #f1f1f3; }
-    .crm-action:disabled { opacity: 0.55; cursor: progress; }
+    .crm-action.is-reinstate { background: #fff; color: #0F1115; border-color: #DCDCDF; }
+    .crm-action.is-reinstate:hover:not(:disabled) { background: #F2F2F2; }
+    .crm-action:disabled { opacity: 0.5; cursor: progress; }
 
-    .crm-pagination { display: flex; justify-content: space-between; align-items: center;
-      gap: 12px; padding: 12px 0; border-top: 1px solid #e5e5ea; flex-wrap: wrap; }
-    .crm-page-btn { min-height: 44px; padding: 0 16px; border-radius: 10px;
-      background: #fff; color: #1c1c1e; border: 1px solid #d6d6db; cursor: pointer; font-weight: 500; }
-    .crm-page-btn:hover:not(:disabled) { background: #f1f1f3; }
+    /* ── Pagination ── */
+    .crm-pagination {
+      display: flex; justify-content: space-between; align-items: center;
+      gap: 10px; padding: 12px 0; border-top: 1px solid #DCDCDF; flex-wrap: wrap;
+    }
+    .crm-page-btn {
+      min-height: 44px; padding: 0 16px; border-radius: 10px;
+      background: #fff; color: #0F1115; border: 1px solid #DCDCDF;
+      cursor: pointer; font-weight: 500; font-size: 13px; font-family: inherit;
+    }
+    .crm-page-btn:hover:not(:disabled) { background: #F2F2F2; }
     .crm-page-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-    .crm-page-info { color: #5b5b60; font-size: 0.9rem; }
+    .crm-page-info { color: #6B6F77; font-size: 13px; }
 
-    .crm-empty { color: #6b6b70; font-style: italic; padding: 12px 0; }
+    .crm-empty { color: #6B6F77; font-style: italic; font-size: 14px; padding: 12px 0; }
 
-    .sr-only { position: absolute !important; width: 1px !important; height: 1px !important;
+    .sr-only {
+      position: absolute !important; width: 1px !important; height: 1px !important;
       padding: 0 !important; margin: -1px !important; overflow: hidden !important;
-      clip: rect(0, 0, 0, 0) !important; white-space: nowrap !important; border: 0 !important; }
-
+      clip: rect(0,0,0,0) !important; white-space: nowrap !important; border: 0 !important;
+    }
     :host *:focus-visible { outline: 2px solid #1a3a52; outline-offset: 2px; border-radius: 6px; }
 
-    @media (min-width: 720px) {
+    @media (min-width: 600px) {
       .crm-controls { flex-direction: row; align-items: center; justify-content: space-between; }
-      .crm-search { flex: 1; max-width: 460px; }
+      .crm-search-row { flex: 1; max-width: 420px; }
     }
   `],
 })

--- a/Frontend/beautyApp/src/app/beauty/beauty-admin-flags.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-admin-flags.component.ts
@@ -23,6 +23,7 @@ import {
 import { CommonModule } from '@angular/common';
 
 import { BffLink } from './beauty-bff.types';
+import { BeautyProviderSubHeaderComponent } from './provider/prov-sub-header.component';
 
 export interface AdminFlag {
   key: string;
@@ -49,19 +50,26 @@ export interface FlagToggleEvent {
 @Component({
   selector: 'app-beauty-admin-flags',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, BeautyProviderSubHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flags-page">
-      <header class="flags-header">
-        <div class="flags-brand">
-          <button class="brand-name-btn" (click)="goHome()">Beauty</button>
-          <span class="flags-subtitle">Feature flags</span>
+    <div class="beauty-app prov-shell flags-page">
+      <app-prov-sub-header
+        back="Home"
+        title="Feature flags"
+        (backClick)="goHome()"
+      >
+        <div slot="right" class="flags-header-right">
+          <button
+            *ngIf="links['crm']"
+            type="button"
+            class="flags-nav-btn"
+            data-testid="flags-nav-crm"
+            (click)="followLink.emit(links['crm'])"
+          >CRM</button>
+          <span class="flags-admin-badge" *ngIf="adminEmail">{{ adminEmail }}</span>
         </div>
-        <div class="flags-admin-badge" *ngIf="adminEmail">
-          {{ adminEmail }}
-        </div>
-      </header>
+      </app-prov-sub-header>
 
       <main id="main" class="flags-main">
         <span class="sr-only" role="status" aria-live="polite">{{ flagAnnouncement }}</span>
@@ -126,42 +134,54 @@ export interface FlagToggleEvent {
     </div>
   `,
   styles: [`
-    :host { display: block; min-height: 100dvh; background: #f7f7f8; color: #1c1c1e;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-    .flags-page { max-width: 860px; margin: 0 auto; padding: 24px 20px 64px; }
-    .flags-header { display: flex; justify-content: space-between; align-items: center;
-      padding-bottom: 16px; border-bottom: 1px solid #e5e5ea; margin-bottom: 24px; }
-    .flags-brand { display: flex; align-items: baseline; gap: 12px; }
-    .brand-name-btn { background: none; border: none; padding: 0; cursor: pointer;
-      font-size: 1.5rem; font-weight: 700; color: #1c1c1e; }
-    .flags-subtitle { color: #6b6b70; font-size: 0.95rem; }
-    .flags-admin-badge { font-size: 0.85rem; padding: 6px 12px; border-radius: 999px;
-      background: #1c1c1e; color: #fff; }
-    .flags-intro h1 { margin: 0 0 8px; font-size: 1.6rem; }
-    .flags-intro p { margin: 0 0 24px; color: #5b5b60; line-height: 1.4; }
-    .flags-list { display: grid; gap: 12px; margin-bottom: 32px; }
-    .flag-card { display: flex; justify-content: space-between; gap: 16px;
-      background: #fff; border: 1px solid #e5e5ea; border-radius: 12px; padding: 16px 18px; }
+    :host {
+      display: block;
+      font-family: 'Inter', system-ui, sans-serif;
+    }
+    .beauty-app {
+      display: flex; flex-direction: column;
+      min-height: 100dvh;
+      background: #F2F2F2;
+      color: #0F1115;
+    }
+    .flags-page {}
+    .flags-header-right {
+      display: flex; align-items: center; gap: 10px; flex-shrink: 0;
+    }
+    .flags-nav-btn {
+      background: transparent; border: 1px solid #DCDCDF;
+      border-radius: 8px; padding: 0 12px;
+      min-height: 36px; cursor: pointer;
+      font-family: inherit; font-size: 13px; font-weight: 500;
+      color: #0F1115;
+    }
+    .flags-nav-btn:hover { background: #EBEBEB; }
+    .flags-admin-badge {
+      font-size: 12px; padding: 4px 10px; border-radius: 999px;
+      background: #0F1115; color: #fff; white-space: nowrap;
+    }
+    .flags-main {
+      flex: 1; overflow-y: auto;
+      padding: 16px 14px 64px;
+      display: flex; flex-direction: column; gap: 14px;
+    }
+    .flags-intro h1 { margin: 0 0 6px; font-size: 22px; font-family: 'Cormorant Garamond', Georgia, serif; font-weight: 500; }
+    .flags-intro p { margin: 0; color: #6B6F77; font-size: 13px; line-height: 1.5; }
+    .flags-list { display: grid; gap: 10px; }
+    .flag-card { display: flex; justify-content: space-between; gap: 16px; align-items: center;
+      background: #fff; border: 1px solid #DCDCDF; border-radius: 14px; padding: 16px 18px; }
     .flag-info { flex: 1; min-width: 0; }
-    .flag-label { margin: 0 0 4px; font-size: 1.05rem; }
-    .flag-key { display: inline-block; font-size: 0.78rem; color: #6b6b70;
-      background: #f1f1f3; padding: 2px 6px; border-radius: 6px; }
-    .flag-description { margin: 8px 0 0; color: #4a4a4f; font-size: 0.92rem; line-height: 1.4; }
-    .flag-control { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; }
-    .flag-state { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .flag-label { margin: 0 0 4px; font-size: 15px; font-weight: 600; color: #0F1115; }
+    .flag-key { display: inline-block; font-size: 12px; color: #6B6F77;
+      background: #F2F2F2; padding: 2px 6px; border-radius: 6px; }
+    .flag-description { margin: 8px 0 0; color: #6B6F77; font-size: 13px; line-height: 1.4; }
+    .flag-control { display: flex; flex-direction: column; align-items: flex-end; gap: 8px; padding: 8px 0; min-height: 44px; }
+    .flag-state { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; }
     .flag-state--on { color: #0f7a3a; }
     .flag-state--off { color: #94343b; }
     .flag-toggle { position: relative; width: 52px; height: 30px; border-radius: 999px;
-      border: none; background: #8e8e93; cursor: pointer; padding: 0; transition: background 0.18s ease;
-      /* Keep visual track 30px but extend hit-target to 44px via padding-free margin block */
-    }
-    .flag-control { padding: 8px 0; min-height: 44px; }
+      border: none; background: #8e8e93; cursor: pointer; padding: 0; transition: background 0.18s ease; }
     .flag-toggle:focus-visible { outline: 2px solid #1a3a52; outline-offset: 2px; }
-    .sr-only {
-      position: absolute !important; width: 1px !important; height: 1px !important;
-      padding: 0 !important; margin: -1px !important; overflow: hidden !important;
-      clip: rect(0, 0, 0, 0) !important; white-space: nowrap !important; border: 0 !important;
-    }
     :host *:focus-visible { outline: 2px solid #1a3a52; outline-offset: 2px; border-radius: 6px; }
     .flag-toggle:disabled { opacity: 0.55; cursor: progress; }
     .flag-toggle--on { background: #0f7a3a; }
@@ -169,17 +189,22 @@ export interface FlagToggleEvent {
       background: #fff; border-radius: 50%; transition: transform 0.18s ease;
       box-shadow: 0 1px 2px rgba(0,0,0,0.15); }
     .flag-toggle--on .flag-toggle__knob { transform: translateX(22px); }
-    .flags-empty, .audit-empty { color: #6b6b70; font-style: italic; }
-    .flags-audit h2 { margin: 0 0 12px; font-size: 1.2rem; }
+    .flags-empty, .audit-empty { color: #6B6F77; font-style: italic; font-size: 14px; }
+    .flags-audit h2 { margin: 0 0 12px; font-size: 17px; font-weight: 600; }
     .audit-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 8px; }
     .audit-item { display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
-      background: #fff; border: 1px solid #e5e5ea; border-radius: 10px; padding: 10px 14px;
-      font-size: 0.9rem; }
-    .audit-when { color: #6b6b70; font-variant-numeric: tabular-nums; min-width: 160px; }
-    .audit-key { background: #f1f1f3; padding: 2px 6px; border-radius: 6px; font-size: 0.78rem; }
-    .audit-change strong { color: #1c1c1e; }
-    .audit-who { color: #5b5b60; }
+      background: #fff; border: 1px solid #DCDCDF; border-radius: 10px; padding: 10px 14px;
+      font-size: 13px; }
+    .audit-when { color: #6B6F77; font-variant-numeric: tabular-nums; min-width: 160px; }
+    .audit-key { background: #F2F2F2; padding: 2px 6px; border-radius: 6px; font-size: 12px; }
+    .audit-change strong { color: #0F1115; }
+    .audit-who { color: #6B6F77; }
     .audit-who em { color: #8a8a8e; font-style: normal; }
+    .sr-only {
+      position: absolute !important; width: 1px !important; height: 1px !important;
+      padding: 0 !important; margin: -1px !important; overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important; white-space: nowrap !important; border: 0 !important;
+    }
   `],
 })
 export class BeautyAdminFlagsComponent {
@@ -187,6 +212,7 @@ export class BeautyAdminFlagsComponent {
   @Input() audit: AdminFlagAuditEntry[] = [];
   @Input() adminEmail: string | null = null;
   @Input() busyKey: string | null = null;
+  @Input() links: Record<string, BffLink> = {};
 
   @Output() toggleFlag = new EventEmitter<FlagToggleEvent>();
   @Output() followLink = new EventEmitter<BffLink>();

--- a/Frontend/beautyApp/src/app/beauty/beauty-business-service-form.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-business-service-form.component.ts
@@ -193,7 +193,7 @@ interface BusinessForm {
     .biz-form { position: relative; }
     .form-card { /* stacks all fields by default */ }
     .field.field-grid { display: inline-block; width: calc(50% - 6px); vertical-align: top; }
-    .field.field-grid:nth-of-type(odd-grid) { margin-right: 12px; }
+    .field.field-grid:nth-of-type(odd) { margin-right: 12px; }
     .field.field-grid + .field.field-grid { margin-left: 12px; }
 
     /* Number with suffix */

--- a/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
@@ -163,7 +163,9 @@ import { BffLink, BffResponse } from './beauty-bff.types';
         [audit]="adminAudit"
         [adminEmail]="adminEmail"
         [busyKey]="busyFlagKey"
+        [links]="bffResponse!._links ?? {}"
         (toggleFlag)="onFlagToggle($event)"
+        (followLink)="followLink($event)"
         (goHomeRequested)="goHome()"
       />
       <app-beauty-admin-crm

--- a/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
@@ -50,7 +50,6 @@ import { BeautyRescheduleComponent } from './beauty-reschedule.component';
 import { BeautyProfileComponent } from './beauty-profile.component';
 import { BeautyChatsComponent } from './beauty-chats.component';
 import { BeautyChatThreadComponent } from './beauty-chat-thread.component';
-import { BeautyBusinessDashboardComponent } from './beauty-business-dashboard.component';
 import { BeautyBusinessServicesComponent } from './beauty-business-services.component';
 import { BeautyBusinessServiceFormComponent } from './beauty-business-service-form.component';
 import { BeautyBusinessAvailabilityComponent } from './beauty-business-availability.component';
@@ -95,7 +94,6 @@ import { BffLink, BffResponse } from './beauty-bff.types';
     BeautyProfileComponent,
     BeautyChatsComponent,
     BeautyChatThreadComponent,
-    BeautyBusinessDashboardComponent,
     BeautyBusinessServicesComponent,
     BeautyBusinessServiceFormComponent,
     BeautyBusinessAvailabilityComponent,

--- a/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
+++ b/Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts
@@ -50,6 +50,7 @@ import { BeautyRescheduleComponent } from './beauty-reschedule.component';
 import { BeautyProfileComponent } from './beauty-profile.component';
 import { BeautyChatsComponent } from './beauty-chats.component';
 import { BeautyChatThreadComponent } from './beauty-chat-thread.component';
+import { BeautyBusinessDashboardComponent } from './beauty-business-dashboard.component';
 import { BeautyBusinessServicesComponent } from './beauty-business-services.component';
 import { BeautyBusinessServiceFormComponent } from './beauty-business-service-form.component';
 import { BeautyBusinessAvailabilityComponent } from './beauty-business-availability.component';
@@ -94,6 +95,7 @@ import { BffLink, BffResponse } from './beauty-bff.types';
     BeautyProfileComponent,
     BeautyChatsComponent,
     BeautyChatThreadComponent,
+    BeautyBusinessDashboardComponent,
     BeautyBusinessServicesComponent,
     BeautyBusinessServiceFormComponent,
     BeautyBusinessAvailabilityComponent,

--- a/Playwright/features/Pogoda/Beauty/beauty_admin_crm.feature
+++ b/Playwright/features/Pogoda/Beauty/beauty_admin_crm.feature
@@ -6,6 +6,13 @@ Feature: Beauty Admin CRM
     Then the CRM directory should render
     And the page should show both customer and business rows
 
+  Scenario: CRM page uses the app shell layout
+    Given I am signed in as a beauty admin with seeded accounts
+    When I open the admin CRM page
+    Then the page should use the beauty-app shell
+    And the page should have a sub-header with the CRM title
+    And the page should have filter tabs
+
   Scenario: Filter tab shows only customer accounts
     Given I am signed in as a beauty admin with seeded accounts
     When I open the admin CRM page

--- a/Playwright/pages/pogoda/beauty/admin_crm_page.py
+++ b/Playwright/pages/pogoda/beauty/admin_crm_page.py
@@ -1,6 +1,8 @@
 """Locators for the admin CRM screen."""
 
-crm_root = "css=div.crm-page"
+crm_page_root = "css=[data-testid='crm-page']"
+crm_shell = "css=div.beauty-app"
+crm_sub_header = "css=.prov-sub-header"
 crm_search_input = "css=[data-testid='crm-search-input']"
 crm_search_submit = "css=[data-testid='crm-search-submit']"
 tab_all = "css=[data-testid='crm-tab-all']"
@@ -14,6 +16,8 @@ suspended_badge = "css=[data-testid='crm-row-suspended']"
 suspended_card = "css=article.crm-card.is-suspended"
 all_cards = "css=article.crm-card"
 all_types = "css=.crm-type"
+flags_nav_btn = "css=[data-testid='crm-nav-flags']"
+admin_badge = "css=[data-testid='crm-admin-badge']"
 
 
 def suspend_btn(kind: str, _id: int) -> str:

--- a/Playwright/steps/beauty/beauty_utils.py
+++ b/Playwright/steps/beauty/beauty_utils.py
@@ -7,7 +7,7 @@ import requests
 BACKEND_PORT = os.getenv('BACKEND_PORT', '8000')
 BACKEND_URL = f"http://localhost:{BACKEND_PORT}"
 TEST_DEVICE_ID = "test-device-playwright-beauty-001"
-BEAUTY_SESSION_COOKIE = "beauty_session"
+BEAUTY_SESSION_COOKIE = "beauty_auth"
 
 _MANAGE_PY_DIR = os.path.join(
     os.path.dirname(__file__), '..', '..', '..', 'Backend', 'controller'

--- a/Playwright/steps/beauty/test_beauty_admin_crm.py
+++ b/Playwright/steps/beauty/test_beauty_admin_crm.py
@@ -2,12 +2,13 @@
 
 Setup notes
 -----------
-The CRM admin surface is gated by the `BEAUTY_ADMIN_PRINCIPALS` env var on
-the Django backend. These tests:
+The CRM admin surface is gated by the `BEAUTY_ADMIN_PRINCIPALS` env var and
+the `beauty_admin_principals` DB table on the Django backend. These tests:
 
 1. Create a fresh customer account via the REST signup endpoint.
-2. Promote that account to admin by monkey-patching the in-process
-   allowlist (same approach as the feature-flags admin tests).
+2. Promote that account to admin by inserting a BeautyAdminPrincipal row via
+   `_set_admin_principal()`.  The DB row is read on every BFF request so no
+   server restart is required.
 3. Sign in via the REST login endpoint to obtain a session cookie.
 4. Inject that cookie into the Playwright browser context and navigate.
 
@@ -64,7 +65,11 @@ def _clear_state():
 
 
 def _shell(cmd: str) -> str:
-    """Run a one-liner in the Django management shell (local, no Docker)."""
+    """Run a one-liner in the Django management shell (local, no Docker).
+
+    Raises RuntimeError if the process exits non-zero or writes to stderr,
+    so DB-seeding failures surface explicitly instead of silently.
+    """
     proc = subprocess.run(
         ["python", "manage.py", "shell", "-c", cmd],
         cwd=_MANAGE_PY_DIR,
@@ -72,27 +77,38 @@ def _shell(cmd: str) -> str:
         text=True,
         timeout=30,
     )
+    if proc.returncode != 0 or proc.stderr.strip():
+        raise RuntimeError(
+            f"_shell() failed (rc={proc.returncode}):\n"
+            f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+        )
     return (proc.stdout or "").strip()
 
 
-_ADMIN_OVERRIDE_FILE = '/tmp/beauty_test_admin_principals'
-
-
 def _set_admin_principal(user_type: str, user_id: int) -> None:
-    """Grant admin access by writing to the dev-only override file.
+    """Grant admin access by inserting a BeautyAdminPrincipal DB row.
 
-    hateoas_service._admin_principal_allowlist() reads this file on every
-    request when DEBUG=True, so no server restart is required.
+    hateoas_service._admin_principal_allowlist() reads this table on every
+    request so no server restart is required.
     """
-    with open(_ADMIN_OVERRIDE_FILE, 'w') as fh:
-        fh.write(f'{user_type}:{user_id}')
+    out = _shell(
+        f"from beauty_api.models import BeautyAdminPrincipal; "
+        f"BeautyAdminPrincipal.objects.get_or_create("
+        f"    user_type='{user_type}', user_id={user_id}); "
+        f"print('ok')"
+    )
+    assert out == 'ok', f"_set_admin_principal failed: {out!r}"
 
 
-def _clear_admin_principal() -> None:
-    try:
-        os.remove(_ADMIN_OVERRIDE_FILE)
-    except FileNotFoundError:
-        pass
+def _clear_admin_principal(user_type: str, user_id: int) -> None:
+    """Remove the BeautyAdminPrincipal DB row for the given principal."""
+    out = _shell(
+        f"from beauty_api.models import BeautyAdminPrincipal; "
+        f"BeautyAdminPrincipal.objects.filter("
+        f"    user_type='{user_type}', user_id={user_id}).delete(); "
+        f"print('ok')"
+    )
+    assert out == 'ok', f"_clear_admin_principal failed: {out!r}"
 
 
 @pytest.fixture(scope="function")
@@ -113,7 +129,7 @@ def beauty_admin():
     user_id = int(user_id_raw)
     _set_admin_principal("customer", user_id)
     yield {"email": email, "password": password, "user_id": user_id}
-    _clear_admin_principal()
+    _clear_admin_principal("customer", user_id)
     delete_test_users(email)
 
 

--- a/Playwright/steps/beauty/test_beauty_admin_crm.py
+++ b/Playwright/steps/beauty/test_beauty_admin_crm.py
@@ -1,12 +1,18 @@
-"""Playwright BDD tests for the Beauty Admin CRM screen.
+"""Playwright tests for the Beauty Admin CRM screen.
 
 Setup notes
 -----------
-The CRM admin surface is gated by the `BEAUTY_ADMIN_PRINCIPALS` env var
-on the Django backend. The fixture seeds a customer account, promotes
-that account into the allowlist via a Django shell call against the
-running backend container, and then signs that user in via the public
-login endpoint to obtain a session cookie.
+The CRM admin surface is gated by the `BEAUTY_ADMIN_PRINCIPALS` env var on
+the Django backend. These tests:
+
+1. Create a fresh customer account via the REST signup endpoint.
+2. Promote that account to admin by monkey-patching the in-process
+   allowlist (same approach as the feature-flags admin tests).
+3. Sign in via the REST login endpoint to obtain a session cookie.
+4. Inject that cookie into the Playwright browser context and navigate.
+
+The `_shell` helper runs `python manage.py shell -c <cmd>` directly
+against the local Backend/controller directory — no Docker required.
 """
 
 import os
@@ -19,9 +25,12 @@ from playwright.sync_api import expect
 
 from Playwright.Hooks.hooks import goto_route, timeout_for_testing
 from Playwright.pages.pogoda.beauty.admin_crm_page import (
-    crm_root,
+    crm_page_root,
+    crm_shell,
+    crm_sub_header,
     crm_search_input,
     crm_search_submit,
+    tab_all,
     tab_customer,
     tab_business,
     page_info,
@@ -33,17 +42,16 @@ from Playwright.pages.pogoda.beauty.admin_crm_page import (
 from .beauty_utils import (
     BACKEND_URL,
     TEST_DEVICE_ID,
+    BEAUTY_SESSION_COOKIE,
     delete_test_users,
 )
-
 
 scenarios("../../features/Pogoda/Beauty/beauty_admin_crm.feature")
 
 
-_MANAGE_PY_DIR = os.path.join(
-    os.path.dirname(__file__), "..", "..", "..", "Backend", "controller"
+_MANAGE_PY_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "Backend", "controller")
 )
-
 
 _STATE: dict = {}
 
@@ -56,37 +64,40 @@ def _clear_state():
 
 
 def _shell(cmd: str) -> str:
-    """Run a one-line Django shell command in the backend container."""
-    container = os.environ.get("BACKEND_CONTAINER", "main_frame-backend-1")
+    """Run a one-liner in the Django management shell (local, no Docker)."""
     proc = subprocess.run(
-        ["docker", "exec", container, "python", "manage.py", "shell", "-c", cmd],
-        capture_output=True, text=True, timeout=30,
+        ["python", "manage.py", "shell", "-c", cmd],
+        cwd=_MANAGE_PY_DIR,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
     return (proc.stdout or "").strip()
 
 
-def _set_admin_principal(user_type: str, user_id: int) -> None:
-    """Update the BEAUTY_ADMIN_PRINCIPALS env on the running container.
+_ADMIN_OVERRIDE_FILE = '/tmp/beauty_test_admin_principals'
 
-    Implementation note: the env-var on a running container can't be
-    rewritten in-place. Instead we monkey-patch the in-memory allowlist
-    helper so that the running Django process treats the new principal
-    as admin without a restart.
+
+def _set_admin_principal(user_type: str, user_id: int) -> None:
+    """Grant admin access by writing to the dev-only override file.
+
+    hateoas_service._admin_principal_allowlist() reads this file on every
+    request when DEBUG=True, so no server restart is required.
     """
-    cmd = (
-        "from bff_api.services import hateoas_service as h; "
-        f"h._admin_principal_allowlist = lambda: {{('{user_type}', {user_id})}}; "
-        "from beauty_api import admin_views, admin_crm_views; "
-        "import importlib; importlib.reload(admin_views); importlib.reload(admin_crm_views); "
-        "print('ok')"
-    )
-    out = _shell(cmd)
-    assert "ok" in out, f"Failed to patch admin allowlist: {out}"
+    with open(_ADMIN_OVERRIDE_FILE, 'w') as fh:
+        fh.write(f'{user_type}:{user_id}')
+
+
+def _clear_admin_principal() -> None:
+    try:
+        os.remove(_ADMIN_OVERRIDE_FILE)
+    except FileNotFoundError:
+        pass
 
 
 @pytest.fixture(scope="function")
 def beauty_admin():
-    """Create a customer, mark them admin in-process, return creds."""
+    """Create a customer, mark them admin, return credentials."""
     email = f"crmadmin_{uuid.uuid4().hex[:8]}@beauty-test.com"
     password = "AdminPass123!"
     resp = requests.post(
@@ -94,77 +105,115 @@ def beauty_admin():
         json={"email": email, "password": password},
         timeout=10,
     )
-    assert resp.status_code == 201, f"Setup failed: {resp.text}"
-    user_id = int(_shell(
+    assert resp.status_code == 201, f"Admin signup failed: {resp.text}"
+    user_id_raw = _shell(
         f"from beauty_api.models import BeautyUser; "
         f"print(BeautyUser.objects.get(email='{email}').id)"
-    ))
+    )
+    user_id = int(user_id_raw)
     _set_admin_principal("customer", user_id)
     yield {"email": email, "password": password, "user_id": user_id}
+    _clear_admin_principal()
     delete_test_users(email)
 
 
-def _seed_accounts(unique_tag: str, login_email: str, login_password: str) -> dict:
-    """Seed several customer + business rows for the CRM list."""
+def _seed_accounts(unique_tag: str) -> None:
+    """Seed 3 customers + 3 businesses with recognisable emails."""
     cmd = (
         "from beauty_api.models import BeautyUser, BusinessProvider; "
         "from django.contrib.auth.hashers import make_password; "
         f"tag = '{unique_tag}'; "
-        "for i in range(1, 4): "
-        "    BeautyUser.objects.get_or_create(email=f'crmtest_cust_{tag}_{i}@beauty-test.com', "
-        "        defaults={'password': make_password('!')}); "
-        "for i in range(1, 4): "
-        "    BusinessProvider.objects.get_or_create(email=f'crmtest_biz_{tag}_{i}@beauty-test.com', "
-        "        defaults={'password': make_password('!'), 'business_name': f'Studio_{tag}_{i}'}); "
-        f"u, _ = BeautyUser.objects.get_or_create(email='{login_email}', "
-        f"    defaults={{'password': make_password('{login_password}')}}); "
-        f"u.set_password('{login_password}'); u.save(update_fields=['password']); "
+        "[(BeautyUser.objects.get_or_create("
+        "    email=f'crmtest_cust_{tag}_{i}@beauty-test.com',"
+        "    defaults={'password': make_password('!')})) for i in range(1, 4)]; "
+        "[(BusinessProvider.objects.get_or_create("
+        "    email=f'crmtest_biz_{tag}_{i}@beauty-test.com',"
+        "    defaults={'password': make_password('!'),"
+        "              'business_name': f'Studio_{tag}_{i}'})) for i in range(1, 4)]; "
+        "print('seeded')"
+    )
+    out = _shell(cmd)
+    assert "seeded" in out, f"Seed failed: {out!r}"
+
+
+def _seed_target_customer(tag: str, email: str, password: str) -> int:
+    """Create (or reset) a plain customer whose ID we need for suspend tests."""
+    cmd = (
+        "from beauty_api.models import BeautyUser; "
+        "from django.contrib.auth.hashers import make_password; "
+        f"u, _ = BeautyUser.objects.get_or_create("
+        f"    email='{email}', defaults={{'password': make_password('{password}')}}); "
+        f"u.set_password('{password}'); u.save(update_fields=['password']); "
         "print(u.id)"
     )
-    target_id = int(_shell(cmd))
-    return {"target_id": target_id}
+    return int(_shell(cmd))
+
+
+def _cleanup_seeded(tag: str) -> None:
+    _shell(
+        "from beauty_api.models import BeautyUser, BusinessProvider; "
+        f"BeautyUser.objects.filter(email__contains='crmtest_').delete(); "
+        f"BusinessProvider.objects.filter(email__contains='crmtest_').delete(); "
+        "print('cleaned')"
+    )
 
 
 @pytest.fixture(scope="function")
 def seeded(beauty_admin):
     tag = uuid.uuid4().hex[:6]
-    login_email = f"crmtest_login_{tag}@beauty-test.com"
-    login_password = "SeedPass123!"
-    info = _seed_accounts(tag, login_email, login_password)
+    _seed_accounts(tag)
+    target_email = f"crmtest_login_{tag}@beauty-test.com"
+    target_password = "SeedPass123!"
+    target_id = _seed_target_customer(tag, target_email, target_password)
     yield {
         "tag": tag,
         "admin": beauty_admin,
-        "target_email": login_email,
-        "target_password": login_password,
-        "target_id": info["target_id"],
+        "target_email": target_email,
+        "target_password": target_password,
+        "target_id": target_id,
     }
-    # Cleanup seeded rows.
-    cleanup = (
-        "from beauty_api.models import BeautyUser, BusinessProvider; "
-        f"BeautyUser.objects.filter(email__contains='crmtest_').delete(); "
-        f"BusinessProvider.objects.filter(email__contains='crmtest_').delete(); "
-        "print('ok')"
-    )
-    _shell(cleanup)
+    _cleanup_seeded(tag)
 
 
-def _login_admin(page, admin):
+def _login_admin(page, admin: dict) -> None:
+    """Sign in the admin via REST and attach the session cookie.
+
+    The Angular app reads `beauty_device_id` from localStorage and sends it as
+    the X-Device-ID header on every BFF call.  The backend cookie embeds the
+    same device_id and validates the two match.  We therefore pre-seed
+    localStorage with TEST_DEVICE_ID *before* navigating so Angular picks up
+    the same value that was used during REST login.
+    """
     resp = requests.post(
         f"{BACKEND_URL}/api/beauty/login/",
-        json={"email": admin["email"], "password": admin["password"], "device_id": TEST_DEVICE_ID},
+        json={
+            "email": admin["email"],
+            "password": admin["password"],
+            "device_id": TEST_DEVICE_ID,
+        },
         timeout=10,
     )
     assert resp.status_code == 200, f"Admin login failed: {resp.text}"
-    cookie = resp.cookies.get("beauty_auth")
-    assert cookie, "Login did not set auth cookie."
+    cookie = resp.cookies.get(BEAUTY_SESSION_COOKIE)
+    assert cookie, f"Login did not set {BEAUTY_SESSION_COOKIE!r} cookie."
     page.context.add_cookies([{
-        "name": "beauty_auth",
+        "name": BEAUTY_SESSION_COOKIE,
         "value": cookie,
         "domain": "localhost",
         "path": "/",
         "httpOnly": False,
     }])
+    # Pre-seed localStorage so Angular reads the same device_id that is encoded
+    # in the signed session cookie above.  add_init_script runs before any page
+    # script on every subsequent navigation in this context.
+    page.context.add_init_script(
+        f"localStorage.setItem('beauty_device_id', '{TEST_DEVICE_ID}');"
+    )
 
+
+# ---------------------------------------------------------------------------
+# Step definitions
+# ---------------------------------------------------------------------------
 
 @given("I am signed in as a beauty admin with seeded accounts")
 def signed_in(page, seeded):
@@ -175,8 +224,10 @@ def signed_in(page, seeded):
 @when("I open the admin CRM page")
 def open_crm(page):
     goto_route(page, "beauty_admin_crm")
-    timeout_for_testing(page)
-    expect(page.locator(crm_root)).to_be_visible()
+    # Angular dev server may take up to 20 s to bootstrap on first load.
+    # Wait for app-root to have rendered content before asserting specifics.
+    page.wait_for_selector("app-beauty-shell, [data-testid]", timeout=25000)
+    expect(page.locator(crm_page_root)).to_be_visible(timeout=10000)
 
 
 @then("the CRM directory should render")
@@ -186,8 +237,26 @@ def directory_renders(page):
 
 @then("the page should show both customer and business rows")
 def both_types_render(page):
-    types = page.locator("css=.crm-type").all_inner_texts()
-    assert "Customer" in types and "Business" in types, f"Types saw: {types}"
+    types = [t.upper() for t in page.locator("css=.crm-type").all_inner_texts()]
+    assert "CUSTOMER" in types and "BUSINESS" in types, f"Types saw: {types}"
+
+
+@then("the page should use the beauty-app shell")
+def uses_app_shell(page):
+    expect(page.locator(crm_shell)).to_be_visible()
+
+
+@then("the page should have a sub-header with the CRM title")
+def has_sub_header(page):
+    expect(page.locator(crm_sub_header)).to_be_visible()
+    expect(page.locator("css=.prov-sub-header .title")).to_contain_text("CRM")
+
+
+@then("the page should have filter tabs")
+def has_filter_tabs(page):
+    expect(page.locator(tab_all)).to_be_visible()
+    expect(page.locator(tab_customer)).to_be_visible()
+    expect(page.locator(tab_business)).to_be_visible()
 
 
 @when("I click the customers tab")
@@ -200,7 +269,7 @@ def click_customer_tab(page):
 def all_customer(page):
     types = page.locator("css=.crm-type").all_inner_texts()
     assert types, "No rows visible"
-    assert all(t == "Customer" for t in types), f"Types: {types}"
+    assert all(t.upper() == "CUSTOMER" for t in types), f"Types: {types}"
 
 
 @when("I click the businesses tab")
@@ -213,7 +282,7 @@ def click_business_tab(page):
 def all_business(page):
     types = page.locator("css=.crm-type").all_inner_texts()
     assert types, "No rows visible"
-    assert all(t == "Business" for t in types), f"Types: {types}"
+    assert all(t.upper() == "BUSINESS" for t in types), f"Types: {types}"
 
 
 @when("I search for the unique business")
@@ -251,7 +320,7 @@ def page_two(page):
 def suspend_target(page):
     target_id = _STATE["target_id"]
     page.locator(suspend_btn("customer", target_id)).click()
-    page.wait_for_timeout(1000)
+    page.wait_for_timeout(1200)
 
 
 @then("the suspended badge should be visible")
@@ -270,14 +339,16 @@ def login_blocked(page):
         },
         timeout=10,
     )
-    assert resp.status_code == 403, f"Suspended account login should be 403, got {resp.status_code}: {resp.text}"
+    assert resp.status_code == 403, (
+        f"Suspended account login should be 403, got {resp.status_code}: {resp.text}"
+    )
 
 
 @when("I reinstate the seeded login customer")
 def reinstate_target(page):
     target_id = _STATE["target_id"]
     page.locator(reinstate_btn("customer", target_id)).click()
-    page.wait_for_timeout(1000)
+    page.wait_for_timeout(1200)
 
 
 @then("the seeded customer should be able to log in")
@@ -291,4 +362,6 @@ def login_works(page):
         },
         timeout=10,
     )
-    assert resp.status_code == 200, f"Reinstated account should log in, got {resp.status_code}: {resp.text}"
+    assert resp.status_code == 200, (
+        f"Reinstated account should log in, got {resp.status_code}: {resp.text}"
+    )

--- a/attached_assets/Pasted-task-31-Replace-tmp-file-admin-override-with-DB-backed-_1778300775478.txt
+++ b/attached_assets/Pasted-task-31-Replace-tmp-file-admin-override-with-DB-backed-_1778300775478.txt
@@ -1,0 +1,43 @@
+task-31: Replace /tmp file admin override with DB-backed BeautyAdminPrincipal
+Original task: Make admin CRM Playwright tests still pass after the
+DEBUG-gated /tmp/beauty_test_admin_principals file-read block was
+removed from hateoas_service.py.
+
+## Backend changes
+
+- Added BeautyAdminPrincipal model to beauty_api/models.py:
+unique (user_type, user_id) rows stored in beauty_admin_principals
+table; same pattern as BeautyFeatureFlag — queried per-request.
+- Created migration 0014_beauty_admin_principal.
+- Updated hateoas_service._admin_principal_allowlist():
+removed DEBUG-gated /tmp file-read block; now reads from both
+BEAUTY_ADMIN_PRINCIPALS env var AND the new DB table.
+DB-read exceptions are now logged via logger.warning (not silently
+swallowed) so failures are diagnosable.
+Removed unused from django.conf import settings import.
+
+## Playwright test changes
+
+- test_beauty_admin_crm.py:
+- _shell() now raises RuntimeError on non-zero exit code or stderr
+output so DB-seeding failures surface explicitly instead of silently.
+- _set_admin_principal() inserts a BeautyAdminPrincipal row via
+_shell() and asserts the "ok" sentinel from stdout.
+- _clear_admin_principal() deletes the row via _shell() with same
+assertion; now takes (user_type, user_id) instead of no args.
+- beauty_admin fixture updated to pass both args to _clear_admin_principal.
+- Docstring updated to describe DB-backed mechanism.
+- No /tmp file references remain anywhere.
+
+## Beauty dev server fix (bonus — required for tests to run at all)
+
+- Added servePath: "/pogoda/beauty/" to Frontend/beautyApp/angular.json
+serve options. Without this the Vite dev server served assets at the
+root (/styles.css) but the browser requested /pogoda/beauty/styles.css
+per the tag, causing 404s and Angular
+failing to bootstrap. All 7 CRM browser tests were blocked by this.
+This is intentional and required for Playwright tests to work in dev.
+
+## Result
+All 7 tests in test_beauty_admin_crm.py pass (7 passed in 83.64s).
+No /tmp file approach remains in production code or tests.

--- a/attached_assets/Pasted-task-31-Replace-tmp-file-admin-override-with-DB-backed-_1778301287290.txt
+++ b/attached_assets/Pasted-task-31-Replace-tmp-file-admin-override-with-DB-backed-_1778301287290.txt
@@ -1,0 +1,43 @@
+task-31: Replace /tmp file admin override with DB-backed BeautyAdminPrincipal
+Original task: Make admin CRM Playwright tests still pass after the
+DEBUG-gated /tmp/beauty_test_admin_principals file-read block was
+removed from hateoas_service.py.
+
+## Backend changes
+
+- Added BeautyAdminPrincipal model to beauty_api/models.py:
+unique (user_type, user_id) rows stored in beauty_admin_principals
+table; same pattern as BeautyFeatureFlag — queried per-request.
+- Created migration 0014_beauty_admin_principal.
+- Updated hateoas_service._admin_principal_allowlist():
+removed DEBUG-gated /tmp file-read block; now reads from both
+BEAUTY_ADMIN_PRINCIPALS env var AND the new DB table.
+DB-read exceptions are now logged via logger.warning (not silently
+swallowed) so failures are diagnosable.
+Removed unused from django.conf import settings import.
+
+## Playwright test changes
+
+- test_beauty_admin_crm.py:
+- _shell() now raises RuntimeError on non-zero exit code or stderr
+output so DB-seeding failures surface explicitly instead of silently.
+- _set_admin_principal() inserts a BeautyAdminPrincipal row via
+_shell() and asserts the "ok" sentinel from stdout.
+- _clear_admin_principal() deletes the row via _shell() with same
+assertion; now takes (user_type, user_id) instead of no args.
+- beauty_admin fixture updated to pass both args to _clear_admin_principal.
+- Docstring updated to describe DB-backed mechanism.
+- No /tmp file references remain anywhere.
+
+## Beauty dev server fix (bonus — required for tests to run at all)
+
+- Added servePath: "/pogoda/beauty/" to Frontend/beautyApp/angular.json
+serve options. Without this the Vite dev server served assets at the
+root (/styles.css) but the browser requested /pogoda/beauty/styles.css
+per the tag, causing 404s and Angular
+failing to bootstrap. All 7 CRM browser tests were blocked by this.
+This is intentional and required for Playwright tests to work in dev.
+
+## Result
+All 7 tests in test_beauty_admin_crm.py pass (7 passed in 83.64s).
+No /tmp file approach remains in production code or tests.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+WORKSPACE=/home/runner/workspace
+
+echo "==> Running Django migrations..."
+cd "$WORKSPACE/Backend/controller"
+python manage.py migrate --no-input
+
+echo "==> Starting Django backend on port 8000..."
+gunicorn --bind 0.0.0.0:8000 --workers 2 --daemon \
+  --log-file "$WORKSPACE/gunicorn.log" \
+  --access-logfile "$WORKSPACE/gunicorn-access.log" \
+  main_frame_project.wsgi:application
+
+echo "==> Starting unified frontend server on port 5000..."
+cd "$WORKSPACE"
+node server.js

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,13 +5,25 @@ WORKSPACE=/home/runner/workspace
 
 echo "==> Running Django migrations..."
 cd "$WORKSPACE/Backend/controller"
-python manage.py migrate --no-input
+DJANGO_SETTINGS_MODULE=main_frame_project.settings python manage.py migrate --no-input
 
 echo "==> Starting Django backend on port 8000..."
-gunicorn --bind 0.0.0.0:8000 --workers 2 --daemon \
-  --log-file "$WORKSPACE/gunicorn.log" \
-  --access-logfile "$WORKSPACE/gunicorn-access.log" \
-  main_frame_project.wsgi:application
+DJANGO_SETTINGS_MODULE=main_frame_project.settings \
+  gunicorn --bind 0.0.0.0:8000 --workers 2 main_frame_project.wsgi:application &
+
+echo "==> Waiting for backend to be ready on port 8000..."
+timeout=60
+elapsed=0
+until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',8000),1); s.close()" 2>/dev/null; do
+  if [ "$elapsed" -ge "$timeout" ]; then
+    echo "ERROR: Backend did not bind to port 8000 within ${timeout}s"
+    exit 1
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+  echo "  ... waiting (${elapsed}s)"
+done
+echo "==> Backend is ready."
 
 echo "==> Starting unified frontend server on port 5000..."
 cd "$WORKSPACE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1040 @@
+{
+  "name": "pogoda-unified-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pogoda-unified-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "http-proxy-middleware": "^2.0.6"
+      }
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pogoda-unified-server",
+  "version": "1.0.0",
+  "description": "Unified static + proxy server for Replit deployment",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6"
+  }
+}

--- a/replit.md
+++ b/replit.md
@@ -1,82 +1,557 @@
 # Portfolio Resume Application
 
-A full-stack portfolio + beauty booking platform. Kevin Ortiz's portfolio on one side; a beauty marketplace (browse, book, manage) on the other.
+## Architecture: Beauty App Separation (May 2, 2026)
 
-## Run & Operate
+The Beauty booking app (`/pogoda/beauty/*`) has been extracted from the portfolio Angular project into its own standalone Angular application to eliminate cross-vulnerability risk.
 
-| Service | Command | Port |
-|---|---|---|
-| Frontend (portfolio) | `ng serve --port 5000` | 5000 |
-| Beauty app | `ng serve --port 4200` | 4200 |
-| Backend | `python manage.py runserver 0.0.0.0:8000` | 8000 |
+### Project Structure
+- **`Frontend/portfolioResume/`** — Kevin/Pogoda portfolio (Angular 19, port 5000 in dev)
+- **`Frontend/beautyApp/`** — Beauty booking app (Angular 19 + NgRx, port 4200 in dev)
+- **`Backend/controller/`** — Django BFF (port 8000)
 
-**Required env vars / secrets**: `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGPORT` (Neon/PostgreSQL), `SESSION_SECRET`, `GITHUB_TOKEN`.  
-**DB fallback**: set `DJANGO_DB=sqlite` to use SQLite when the Neon endpoint is unavailable (dev only).  
-**After DB reprovisioning**: run `cd Backend/controller && python manage.py migrate`.
+### How Routing Works
+- In **Docker** (`docker-compose.yml`): the portfolio nginx proxies all `/pogoda/beauty/*` requests to the `beauty_frontend` container (internal port 80). Both apps share the same public-facing port.
+- In **dev** (`Playwright` tests): `FRONTEND_PORT` (default 5000) → portfolio routes; `BEAUTY_PORT` (default 4200) → beauty routes. The `hooks.py` router selects the port automatically by route key.
 
-## Stack
+### Workflows
+- `frontend` — portfolio Angular dev server on port 5000
+- `beauty` — beauty Angular dev server on port 4200
+- `backend` — Django dev server on port 8000
 
-- **Frontend**: Angular 19 SSR (portfolio, port 5000) + Angular 19 SPA (beauty, port 4200)
-- **Backend**: Django 5.1 + Django REST Framework, BCryptSHA256 password hashing
-- **DB**: PostgreSQL via Neon (Replit-managed); SQLite fallback for dev
-- **Auth**: HttpOnly signed cookie (`beauty_session`) + device-ID binding
-- **Testing**: Playwright + pytest-bdd (in `Playwright/`)
+### Key Files
+| File | Purpose |
+|---|---|
+| `Frontend/beautyApp/src/app/app.routes.ts` | All 26 `/pogoda/beauty/*` routes |
+| `Frontend/beautyApp/src/app/beauty/` | All beauty components, services, guards, store |
+| `Frontend/portfolioResume/nginx.conf` | Proxies `/pogoda/beauty` → `beauty_frontend:80` |
+| `docker-compose.yml` | Added `beauty_frontend` service |
+| `Playwright/Hooks/hooks.py` | Routes beauty test URLs to `BEAUTY_PORT` |
 
-## Where things live
+### What Was Removed from Portfolio
+- All files under `src/app/Pogoda-Software-Pages/beauty/` deleted
+- `@ngrx/store` and `@ngrx/effects` removed from `portfolioResume/package.json`
+- Beauty route imports removed from `portfolioResume/src/app/app.routes.ts`
+- `**` wildcard now shows a simple portfolio 404 page instead of `BeautyErrorComponent`
 
+## Recent Changes (April 18, 2026) — 24-hour Availability + Local-Time Display
+
+Two related improvements so a 24-hour shop (e.g. an all-night hairdresser) and an out-of-town customer both work correctly:
+
+### Backend
+- New `is_24h` BooleanField on `BeautyProviderAvailability` (migration 0007). When true, that day's `start_time`/`end_time` are ignored and the provider is treated as open the full 24 hours.
+- `availability_service`:
+  - `compute_slots()`: 24h days now generate slots from 00:00 to 24:00 UTC (the next day's midnight is used as the close boundary so the last partial slot still fits).
+  - `is_slot_available()`: skips the business-hours window check when the day is marked 24h.
+  - `replace_weekly_hours()`/`get_weekly_hours()`/`_row_to_dict()`: accept and round-trip the new flag, treating closed and 24h as mutually exclusive.
+
+### Frontend
+- New `beauty-time.util.ts` exports `formatSlotLocal(iso)` which renders an ISO timestamp using `Intl.DateTimeFormat` with **no `timeZone`**, so each viewer sees the slot on their own browser clock — exactly what an out-of-town customer needs.
+- `BeautyBookComponent` and `BeautyRescheduleComponent` now show option labels via `slotLabel(o)` instead of the BFF's UTC string.
+- `BeautyBookingDetailComponent` and `BeautyBookingsComponent` now render `formatLocal(b.slot_at)` (with the BFF's `slot_label` as a graceful fallback).
+- `BeautyRescheduleComponent`'s "Currently booked for" card now formats `current_slot_at` locally too.
+- `BeautyBusinessAvailabilityComponent`: new "Open 24h" checkbox per day. Toggling it disables the start/end inputs; toggling Closed clears the 24h flag; the row is round-tripped through the existing PUT.
+
+Smoke-tested: marking a day as 24h yields ~44 bookable 30-min slots for a 60-min service across that UTC day (vs. 15 slots/day on a 10–18 day). Customer-side, all slot pickers and booking screens render in the browser's local timezone with the zone abbreviation appended (e.g. "Mon Apr 20 · 7:00 AM PDT").
+
+## Recent Changes (April 18, 2026) — Customer Booking Reschedule (Task #13)
+
+Customers can now move an existing upcoming booking to a different time without cancelling and rebooking.
+
+### Backend
+- New `RescheduleBookingView` at `POST /api/beauty/protected/bookings/<id>/reschedule/` — validates owner, status (`booked`), and that the booking is still in the future, then runs `is_slot_available()` on the new `slot_at` (excluding this booking's own slot from busy intervals so it doesn't block its own move) and updates the row in place. Returns 400 with a clear `detail` for past slots, conflicts, out-of-hours requests, cancelled or past bookings.
+- `availability_service`: `compute_slots()`, `is_slot_available()`, and `_provider_busy_intervals()` all gained an optional `exclude_booking_id` parameter so the reschedule slot picker shows the booking's current slot among the options.
+
+### BFF
+- New `beauty_reschedule` resolver: customer-only, owner-scoped. Returns the slot picker form (`compute_slots(..., exclude_booking_id=b.id)`) plus `submit_method='POST'`, `submit_href='/api/beauty/protected/bookings/<id>/reschedule/'`, and a `success_route_template` that goes back to the booking-detail screen. Past or non-active bookings short-circuit to a redirect envelope back to `beauty_booking_detail` (with `params={id: b.id}` so the redirect lands on the right URL).
+- `beauty_booking_detail` now exposes a `reschedule` HATEOAS link alongside `cancel` for upcoming bookings.
+- `redirect_envelope()` now accepts an optional `params` kwarg so redirect targets with templated routes (like `/bookings/:id`) get rendered with concrete values.
+- Registered `beauty_reschedule` in `SCREEN_RESOLVERS` and mapped it to `/pogoda/beauty/bookings/:bookingId/reschedule` in `SCREEN_ROUTES`.
+
+### Frontend
+- New standalone `BeautyRescheduleComponent` mirrors the booking flow's slot-picker form, shows the current booked time on a card above the picker, posts the new slot via `BeautyAuthService.follow()`, and on success follows the `booking` link back to the booking-detail screen.
+- `BeautyBookingDetailComponent` now renders a primary "Reschedule" button (when the BFF supplies a `reschedule` link) above the existing Cancel/View Provider buttons.
+- `BeautyShellComponent` imports + templates the new component.
+- `app.routes.ts` registers `/pogoda/beauty/bookings/:bookingId/reschedule` (placed before the `:id` detail route so it matches first), guarded by the existing `beautyAuthGuard`.
+
+End-to-end verified via curl: reschedule link present on upcoming bookings, picker contains the current slot, POST succeeds (10:00 → 12:30), booking-detail shows the new time, the old slot becomes bookable again, past slots / conflicts are rejected with `That slot is no longer available.`, cancelled bookings can no longer be rescheduled and lose the `reschedule` link, and the resolver redirects cleanly back to `beauty_booking_detail` for ineligible bookings.
+
+## Recent Changes (April 18, 2026) — Business Provider Portal + Real Availability (Tasks #14 & #15)
+
+Built the full business provider portal so a signed-in business can manage their storefront end-to-end, and replaced the fixed-slot booking generator with real provider availability.
+
+### Backend
+- New model `BeautyProviderAvailability` (`provider`, `day_of_week`, `start_time`, `end_time`, `is_closed`) with a unique `(provider, day_of_week)` constraint. Migration `0006_beauty_provider_availability` creates the table and seeds Mon-Sat 10-18 / Sunday closed for every existing `BeautyProvider`.
+- New `beauty_api/availability_service.py` exposes `get_weekly_hours(provider)` (always 7 rows, auto-creates defaults), `replace_weekly_hours(provider, rows)` (validates + bulk replaces), `compute_slots(service, days_ahead=14)` (steps every 30 min within open hours, skips closed days, skips slots that overlap any existing booking on the same provider, drops past slots), `is_slot_available(service, slot_at)` (server-side validation), and `ensure_storefront(business_provider)` (idempotent storefront bootstrap).
+- New `beauty_api/business_views.py` adds the protected REST surface under `/api/beauty/protected/business/`: `dashboard/` (stats), `services/` GET+POST, `services/<id>/` PUT+DELETE, `availability/` GET+PUT, `bookings/` GET. All handlers reject non-business cookies with 403; future bookings on a deleted service are auto-cancelled before delete.
+- `BusinessLoginView` calls `ensure_storefront()` on every login so a freshly signed-up business has a working storefront with default weekly hours.
+- `booking_views.py` POST now calls `is_slot_available()` so the customer flow respects business hours and overlapping bookings.
+
+### BFF
+- `beauty_book.py` slot list now comes from `compute_slots()` (the fixed `SLOT_HOURS` generator is gone).
+- `beauty_business_login.py` redirects already-signed-in business users to `beauty_business_home` and uses that as its post-login `success_screen`.
+- `beauty_home.py` shows a "Business Portal" link to authenticated business users.
+- 5 new resolvers: `beauty_business_home` (dashboard), `beauty_business_services` (list with edit/delete links), `beauty_business_service_form` (single screen for add+edit, `serviceId=='new'` ⇒ add), `beauty_business_availability` (7-row editor with PUT submit metadata), `beauty_business_bookings` (upcoming/past split).
+- `SCREEN_ROUTES` and `SCREEN_RESOLVERS` registered for all 5 new screens.
+
+### Frontend
+- 5 new standalone Angular components in `src/app/Pogoda-Software-Pages/beauty/`: `beauty-business-dashboard`, `beauty-business-services`, `beauty-business-service-form`, `beauty-business-availability`, `beauty-business-bookings`. All consume `data` + `_links` props and emit `followLink` events the shell handles.
+- `BeautyShellComponent` imports + templates the 5 components and adds them to its screen→route fallback map.
+- `app.routes.ts` adds 6 new routes (one per screen, plus a separate `services/new` route for the add-service form), all guarded by `beautyBusinessAuthGuard`.
+
+## Recent Changes (April 18, 2026) — Runtime Beauty Feature-Flag Admin (Task #8)
+
+Added a small admin screen at `/pogoda/beauty/admin/flags` that lets an authenticated user toggle Beauty BFF feature flags at runtime. Toggles take effect on the very next BFF resolve — no Angular rebuild and no Django restart required.
+
+**Backend:**
+- New models in `beauty_api/models.py`:
+  - `BeautyFeatureFlag` (`key`, `enabled`, `description`, `updated_at`, `updated_by_*`) — the runtime source of truth.
+  - `BeautyFlagAudit` (`flag_key`, `old_value`, `new_value`, `changed_by_*`, `changed_at`) — append-only audit trail.
+  - Migration `0003_beautyfeatureflag_beautyflagaudit.py` creates both tables and seeds default rows for existing flags.
+- `bff_api/services/hateoas_service.py` — `is_business_login_enabled()` / `is_signup_enabled()` now consult the `beauty_feature_flags` table first and fall back to the legacy env-var defaults if the row is missing or the DB is unavailable. New `FEATURE_FLAGS` registry declares every known flag (key, label, description, default) so the admin screen iterates one list. Added `beauty_admin_flags` to `SCREEN_ROUTES`.
+- New resolver `bff_api/resolvers/beauty_admin_flags.py` — auth-required, lists each registered flag with current value + a `toggle` link, plus the 25 most recent audit entries.
+- New endpoint `POST /api/beauty/admin/flags/toggle/` (`beauty_api/admin_views.py`, wired in `beauty_api/urls.py`) — validates the flag key against the registry, upserts the row inside a transaction, writes an audit row, returns the new value.
+- **Authorisation:** both the resolver and the toggle endpoint require the caller's `(user_type, user_id)` pair to appear in the `BEAUTY_ADMIN_PRINCIPALS` env var (comma-separated `<user_type>:<user_id>` pairs, e.g. `customer:1,business:7`). We bind to the stable PK identity rather than email because `BeautyUser` and `BusinessProvider` are independent tables with no cross-table email uniqueness — using email would let a duplicate-email registration in the other table escalate to admin. Authenticated non-admins get 403 from the endpoint and a redirect to `beauty_home` (`reason: forbidden`) from the resolver. The default (no admins) means the surface is locked down until an operator opts in. Helpers: `hateoas_service.is_beauty_admin(user)` and `_admin_principal_allowlist()`.
+
+**Frontend:**
+- New presentational component `beauty-admin-flags.component.ts` — renders the flag list with iOS-style toggle switches and a chronological audit log.
+- `BeautyShellComponent` registers the new screen, holds admin state (`adminFlags`, `adminAudit`, `adminEmail`, `busyFlagKey`), and forwards toggle clicks through `BeautyAuthService.follow(toggle_link, {key, enabled})`. After each successful toggle the shell re-resolves so the new value and the new audit entry appear immediately.
+- New Angular route `/pogoda/beauty/admin/flags` → `BeautyShellComponent` with `data: { screen: 'beauty_admin_flags' }`. Added matching entry to the shell's screen→route fallback map.
+
+**Verified end-to-end:**
+- Resolver returns the flag list with toggle links (200).
+- Toggling `BEAUTY_SIGNUP_ENABLED` off via the API immediately removes the `signup` link from `beauty_home`'s `_links` envelope on the very next resolve, with no restart.
+- Audit entry recorded with the actor's email and user type.
+- Bad flag key → 400; unauthenticated request → 401.
+
+## Recent Changes (April 18, 2026) — HATEOAS + Dynamic Form Schema for Beauty BFF (Task #6)
+
+### What changed — "over-the-air" UI updates
+
+The Beauty BFF was upgraded from a fixed render contract into a fully **hypermedia-driven** one. The Angular shell no longer hardcodes endpoint URLs, screen-to-route mappings, form field lists, or which footer links to show. The backend dictates all of it via a `_links` envelope and a `form` schema, so adding a field, hiding an action via a feature flag, or rerouting a flow ships **without an Angular release**.
+
+**Backend:**
+- `Backend/controller/bff_api/services/hateoas_service.py` — link builders (`link`, `screen_link`, `self_link`), the `SCREEN_ROUTES` map (server is sole source of truth for route paths), form schema builders (`login_form`, `signup_form`, `email_field`, `password_field`, `footer_link`), and feature-flag helpers (`is_business_login_enabled`, `is_signup_enabled`) driven by env vars `BEAUTY_BUSINESS_LOGIN_ENABLED` and `BEAUTY_SIGNUP_ENABLED`.
+- All 8 resolvers refactored to emit a HATEOAS envelope: every render carries `_links: {rel: link_obj}`, every redirect carries `_links.target`. Login/signup/business-login resolvers also emit a full `form` schema (fields, validators, submit href + method, success link, footer links, presentation classes, error messages).
+- Legacy fields (`redirect_to` string, `data.links` screen-name dict) are kept alongside the new envelope so existing tests pass.
+- `bff_api/views.py` bumped `APP_VERSION` to `2.0.0`; registered all 8 resolvers including `beauty_business_providers` and `beauty_sessions`.
+
+**Frontend:**
+- `beauty-bff.types.ts` — shared `BffLink`, `BffFieldSchema`, `BffFormSchema`, `BffResponse` types.
+- `BeautyAuthService` no longer hardcodes login/signup/business/logout URLs. Generic `follow(link, body, includeDeviceId)` posts to whatever URL the BFF supplies, on whatever HTTP method the link declares.
+- `BeautyDynamicFormComponent` — schema-driven form renderer. Iterates the schema's fields, validators, and footer links; preserves all existing CSS classes via the schema's `presentation` block so Playwright selectors remain stable.
+- `BeautyShellComponent` — dropped the local `SCREEN_TO_ROUTE` table. Navigation comes from `link.route`. Handles render and redirect responses; on `(followLink)` events fires the link's HTTP method (or just navigates for `method=NAV`) and re-resolves.
+- `BeautyLoginComponent`, `BeautySignupComponent`, `BeautyBusinessLoginComponent` reduced to thin wrappers around the dynamic form.
+- `BeautyMainComponent` builds its header buttons from the `_links` map (rels `login`, `signup`, `business_login`, `logout`); every CTA emits `(followLink)` with the original `BffLink`.
+
+### Envelope contract (v2.0.0)
+```jsonc
+{
+  "action": "render" | "redirect",
+  "screen": "beauty_login",
+  "data":   { ... },
+  "meta":   { "title": "..." },
+  "_links": {
+    "self":   { "rel": "...", "href": "...", "method": "NAV|GET|POST|...", "screen": "...", "route": "/...", "prompt": "..." },
+    "logout": { ... },
+    "target": { ... }   // only on action=redirect
+  },
+  "form": {              // only on screens that render a form
+    "title": "...",
+    "fields": [{ "name", "type", "label", "placeholder", "required", "min_length", "secret_toggle", "error_messages" }],
+    "submit": <link>,
+    "success": <link>,
+    "presentation": { "page_class", "form_class", "submit_class", ... },
+    "footer_links": [{ "rel", "cta_class", "group_class", "label_prefix" }],
+    "error_status_map": { "401": "..." },
+    "error_default": "..."
+  },
+  "redirect_to": "beauty_login",   // legacy, only on action=redirect
+  "app_version": "2.0.0",
+  "needs_update": false
+}
 ```
-Frontend/portfolioResume/   Kevin/Pogoda portfolio (Angular 19)
-Frontend/beautyApp/         Beauty SPA (Angular 19)
-  src/app/beauty/           All beauty components, guards, services
-  src/app/app.routes.ts     All /pogoda/beauty/* routes (business + customer)
-Backend/controller/
-  beauty_api/               Models, views, middleware, migrations
-  bff_api/                  BFF resolvers, HATEOAS service, screen registry
-  main_frame_project/       Django settings, URLs
-Playwright/
-  features/Pogoda/Beauty/   BDD feature files
-  steps/beauty/             Step implementations + page objects
-  Hooks/hooks.py            Route→URL mapping for test runner
-docker-compose.yml          Wires all three services + nginx proxy
+
+---
+
+## Recent Changes (April 1, 2026) — BFF SDUI Architecture for Beauty App (PR #43)
+
+### What changed
+Implemented a complete **Server-Driven UI (SDUI) / Backend-for-Frontend (BFF)** layer for all `/pogoda/beauty/*` routes. The Angular shell now stores **nothing** — it queries the backend on every navigation and renders exactly what the server instructs.
+
+**Backend — new `bff_api` Django app:**
+- `POST /api/bff/beauty/resolve/` — single entry point for the Angular shell
+- **Microservices:** `auth_service.py` (cookie + device_id validation) and `beauty_config_service.py` (static config)
+- **Screen resolvers:** `beauty_home`, `beauty_login`, `beauty_signup`, `beauty_business_login` — each runs independently, can be unit-tested in isolation
+- Returns `{action: "render" | "redirect", screen, data, meta}` — shell renders what BFF says
+- Registered in `INSTALLED_APPS` and `urls.py` at `/api/bff/`
+
+**Frontend:**
+- `BeautyBffService` — POSTs `{version, screen, device_id}` to resolve endpoint
+- `BeautyShellComponent` — SDUI orchestrator; reads screen from route `data`, re-resolves on every navigation, renders child from BFF response, handles events
+- All four beauty components refactored to **presentational** (accept `@Input() data`, emit `@Output()` events, no localStorage, no Router)
+- `app.routes.ts` — all four beauty paths now point to `BeautyShellComponent` with `data: {screen}`
+
+**Pull Request:** https://github.com/PogodaSoftware/main_frame/pull/43
+
+---
+
+## Recent Changes (March 31, 2026) — bcrypt Password Hashing
+- Replaced Django's default PBKDF2 hasher with **BCryptSHA256PasswordHasher**
+- Added `bcrypt==4.2.1` to `requirements.txt`
+- Configured `PASSWORD_HASHERS` in `settings.py` — bcrypt is primary, PBKDF2 kept as fallback for any existing rows
+- `make_password()` and `check_password()` in models and views use bcrypt automatically — no other code changes needed
+- SHA-256 pre-hashing removes bcrypt's 72-byte input limit
+- Password fields carry **no unique constraint**; only email fields are unique
+- Pull Request: https://github.com/PogodaSoftware/main_frame/pull/42
+
+---
+
+## Recent Changes (March 31, 2026) — Auth Middleware
+- **Beauty Auth Middleware (`beauty_api/middleware.py`):**
+  - `BeautyAuthMiddleware` intercepts all `/api/beauty/protected/*` routes
+  - Validates a Django-signed HttpOnly cookie (`beauty_auth`) — tamper-proof and expiry-checked
+  - Confirms `device_id` inside the cookie matches the `X-Device-ID` request header
+  - Verifies the session record is still active in the DB
+  - Returns HTTP 401 on any failure; Angular guard redirects to login page
+  - Multiple devices stay independent — each gets its own cookie/session
+
+- **New DB models (migration 0002):**
+  - `BeautySession` — tracks (user_id, user_type, device_id, token_hash, expires_at, is_active)
+  - `BusinessProvider` — email, hashed password, business_name
+
+- **New API endpoints:**
+  - `POST /api/beauty/login/` — issues 24-hour HttpOnly SameSite=Strict cookie
+  - `POST /api/beauty/logout/` — invalidates session, clears cookie
+  - `POST /api/beauty/business/login/` and `/business/logout/` — business provider flow
+  - `GET  /api/beauty/protected/me/` — returns current user info; used by Angular auth guard
+
+- **Angular auth (Frontend):**
+  - `BeautyAuthService` — generates persistent device fingerprint (localStorage), sends `X-Device-ID` header
+  - `beautyAuthGuard` and `beautyBusinessAuthGuard` functional route guards
+  - `BeautyLoginComponent` at `/pogoda/beauty/login` (email + password)
+  - `BeautyBusinessLoginComponent` at `/pogoda/beauty/business/login`
+  - Beauty main page header now shows "Sign in" + "Sign up" buttons when logged out
+
+- **Security measures applied:**
+  - HttpOnly cookie — JS cannot read the token (XSS-proof)
+  - SameSite=Strict — cookie never sent on cross-site requests (CSRF-proof)
+  - Secure flag — HTTPS only in production
+  - Django signed token — built-in expiry, tamper-proof
+  - SHA-256 token hash — raw token never stored in DB
+  - Device ID binding — request must match the device the token was issued for
+  - Generic 401 errors — no user enumeration possible
+  - Constant-time `check_password` — prevents timing attacks
+
+- **Pull Request:** https://github.com/PogodaSoftware/main_frame/pull/41
+
+---
+
+## Recent Changes (March 31, 2026) — Beauty App Pages (Mobile-first)
+- Created two new pages under `/pogoda/beauty` and `/pogoda/beauty/signup`
+  - Mobile-first design (iPhone 16/17 393px, Samsung S25 390px, Pixel 9 412px, iPhone 17 Plus 430px)
+  - Main page: dark header with "Beauty" brand + Sign up button, horizontal scrollable service row (Beauty, Lashes, Nails, Makeup), Google Maps placeholder (ready for API key)
+  - Sign-up page: email + password form with validation, show/hide password toggle, loading state
+  - After sign-up, user email saved to localStorage and displayed in header
+  - Google Maps: loads dynamically when `googleMapsApiKey` is set in `src/environments/environment.ts`
+  
+- **Django: beauty_api app:**
+  - New `BeautyUser` model (email, hashed password, created_at) in `beauty_api` app
+  - `POST /api/beauty/signup/` endpoint with email uniqueness and password length validation
+  - Uses Django's built-in password hashing (`make_password`)
+  - Migration applied to PostgreSQL database
+
+- **Angular: @angular/forms added:**
+  - Installed `@angular/forms@19.2.15` for template-driven forms in sign-up page
+
+- **Environment files created:**
+  - `src/environments/environment.ts` (dev) and `src/environments/environment.prod.ts` (prod)
+  - Contains `googleMapsApiKey` (empty by default) and `apiBaseUrl`
+  - angular.json configured with fileReplacements for prod build
+
+## Recent Changes (November 13, 2025)
+- **Pogoda Software - Complete Separation from Kevin's Portfolio**:
+  - Removed all links to Kevin's portfolio from Pogoda navigation (desktop and mobile)
+  - Removed "Kevin's Portfolio" button from Pogoda home page
+  - Pogoda Software section now operates completely independently
+  - Navigation shows only: Home and Experience
+  
+- **PostgreSQL Backend Integration for Pogoda Software**:
+  - **Database**: Created PostgreSQL database with WorkExperience and Education models
+  - **Django REST API**: Built API endpoints at `/api/pogoda/experience/` and `/api/pogoda/education/`
+  - **Anti-Scraping Protection**: Implemented rate limiting (10 requests/minute per IP) using DRF throttling
+  - **Data Migration**: Database seeded with 6 work experiences and 2 education entries from Jaroslaw Pogoda's LinkedIn
+  - **Angular Integration**: Created HTTP service to fetch data dynamically from backend API
+  - **SSR Compatibility**: Added platform detection to only make API calls in browser (not during SSR)
+  - **Fallback System**: Component falls back to static data if API is unavailable for reliability
+  - **CORS Configuration**: Configured CORS to allow frontend access while maintaining security
+  - **Workflows**: Both backend (port 8000) and frontend (port 5000) running successfully
+  
+- **Pogoda Experience Page - Real LinkedIn Data**:
+  - Populated experience page with Jaroslaw Pogoda's actual LinkedIn professional history
+  - Added 6 work experiences: Gesture (current), Per Scholas, Sprint, Azodio.com, Bellevue Hospital, Freelance IT
+  - Updated education with Queens College BS in Computer Science (2010-2016) and Triplebyte certification (2022)
+  - All job descriptions, technologies, dates, and locations now reflect real professional background
+  - Experience extracted from public LinkedIn profile via web search (LinkedIn direct fetch not supported)
+  - Data dynamically loaded from PostgreSQL database via REST API
+
+## Recent Changes (November 12, 2025)
+- **New Pogoda Software Pages**:
+  - Created complete Pogoda Software section with professional experience display
+  - Added navigation and footer components for Pogoda pages
+  - Created `/pogoda` home page with LinkedIn integration
+  - Created `/pogoda/experience` page with professional timeline layout
+  - Modern card-based design with technology tags and timeline visualization
+  
+- **Major Security Upgrade & Dependency Cleanup**:
+  - Angular: Upgraded from 19.0.0 to 19.2.15 (fixed high severity SSR vulnerability)
+  - All packages updated to latest secure versions
+  - **0 security vulnerabilities** remaining (verified with npm audit)
+  
+- **Dependency Reduction**:
+  - **Removed unused frontend dependencies**: @angular/forms, @angular/animations, portfolio-resume-frontend self-reference
+  - **Removed unused dev dependencies**: Karma, Jasmine testing framework (using Playwright for E2E)
+  - **Removed unused backend dependencies**: behave (using pytest-bdd instead)
+  - **Result**: Reduced package count from 1157 to 849 packages (-27% reduction)
+  
+- **Code Cleanup**:
+  - Removed all unused Jasmine/Karma test files (.spec.ts files)
+  - Removed karma.conf.js and test configuration directory
+  - Removed unused backend unit test examples
+  - **Result**: Smaller, more maintainable codebase
+  
+- **SSR Fixes**:
+  - Updated main.server.ts to support Angular 19.2.x SSR API changes (BootstrapContext)
+  - Fixed NG0401 error by properly passing bootstrap context
+  - THREE.js platform detection maintained for browser-only rendering
+  
+- **Bug Fixes from Previous Session** (November 6, 2025):
+  - Added favicon.svg to resolve 404 error in browser console
+  - Fixed SSR compatibility issue with THREE.js by adding platform detection
+  - Ensured browser-specific code only runs in browser context
+  
+- **Verification**: All core functionality tested and working properly
+  - Frontend: Angular 19.2.15 SSR working correctly
+  - Backend: Django 5.1.5 running without issues
+  - Navigation: All routes functioning properly
+  - 3D models: Platform detection prevents SSR errors
+  - Security: 0 vulnerabilities in production and dev dependencies
+
+## Overview
+This is a full-stack portfolio and resume application featuring:
+- **Frontend**: Angular 19 application with Server-Side Rendering (SSR)
+- **Backend**: Django 5.1.5 REST API (currently minimal setup)
+- **Testing**: Playwright-based end-to-end testing suite
+
+The application showcases Kevin Ortiz's portfolio as a Quality Assurance & DevOps Engineer, with sections for About, Experience, Projects, and Contact information.
+
+## Running the Application
+
+This project supports two deployment approaches:
+
+### Option 1: Docker (Universal - Recommended for Local Development)
+The original Docker-based setup works on any system with Docker installed:
+
+```bash
+# Set environment variables
+export FRONTEND_PORT=4200
+export BACKEND_PORT=8000
+
+# Run with docker-compose
+docker-compose up
 ```
 
-Source-of-truth files: `beauty_api/models.py` (DB schema), `bff_api/services/hateoas_service.py` (SCREEN_ROUTES), `app.routes.ts` (Angular routes).
+The application will be available at:
+- Frontend: http://localhost:4200
+- Backend: http://localhost:8000
 
-## Architecture decisions
+### Option 2: Replit (Cloud Development)
+On Replit, Docker is not supported. Instead, the application runs natively:
 
-- **SDUI / BFF pattern**: Angular shell POSTs `{screen, device_id}` to `/api/bff/beauty/resolve/` on every navigation. BFF returns `{action, screen, data, _links, form}` — no hardcoded URLs, route paths, or form fields in the frontend.
-- **Beauty app separation**: Beauty lives in its own Angular project (`beautyApp/`) to isolate its NgRx/feature dependencies from the portfolio. In Docker, nginx proxies `/pogoda/beauty/*` to the beauty container.
-- **Hypermedia links**: All navigation, form submit URLs, and feature-flag visibility come from `_links` in the BFF envelope (HATEOAS). Adding a new action requires only a BFF change.
-- **Application gate**: `application_gate.py` enforces that a business must complete the 6-step onboarding wizard before any portal screen resolves. All business resolvers call it first.
-- **SQLite fallback**: `settings.py` checks `DJANGO_DB=sqlite` so the backend can start without a live Neon endpoint (set automatically via env var).
+**Frontend**: 
+```bash
+cd Frontend/portfolioResume
+npm start -- --port 5000 --host 0.0.0.0
+```
 
-## Product
+**Backend**:
+```bash
+cd Backend/controller
+python manage.py runserver 0.0.0.0:8000
+```
 
-**Customer side** (`/pogoda/beauty/*`):
-- Browse beauty providers by category, view profiles, book slots, manage bookings, reschedule, cancel, chat with provider.
+**Note**: The Angular configuration in `angular.json` is kept universal (no hardcoded ports). Port and host are specified via command-line arguments passed through npm to the Angular dev server in the Replit workflow.
 
-**Business side** (`/pogoda/beauty/business/*`):
-- Sign up → 6-step onboarding wizard (entity/ITIN, services, Stripe stub, weekly hours, tools, ToS review) → portal unlocks.
-- Home dashboard: scrollable month calendar of bookings, earnings arc gauge, bookings-volume card (new vs recurring).
-- Manage services (CRUD), weekly availability, incoming bookings, settings/password/profile.
+## Project Structure
+```
+.
+├── Frontend/portfolioResume/     # Angular 19 frontend application
+│   ├── src/
+│   │   ├── app/
+│   │   │   ├── Kevin-Pages/      # Main portfolio pages
+│   │   │   └── Pogoda-Software-Pages/
+│   │   └── assets/               # Static assets
+│   ├── angular.json              # Angular configuration
+│   └── package.json              # Frontend dependencies
+├── Backend/controller/           # Django backend
+│   ├── main_frame_project/
+│   ├── requirements.txt          # Python dependencies
+│   └── manage.py
+└── Playwright/                   # E2E test suite
+    ├── features/                 # BDD feature files
+    ├── pages/                    # Page object models
+    └── steps/                    # Test step definitions
+```
 
-**Admin** (`/pogoda/beauty/admin/flags`): runtime feature-flag toggle (BEAUTY_SIGNUP_ENABLED, BEAUTY_BUSINESS_LOGIN_ENABLED) with audit trail.
+## Development Setup
 
-## User preferences
+### Frontend (Angular)
+- **Port**: 5000 (configured for Replit)
+- **Host**: 0.0.0.0 (allows Replit proxy access)
+- **Start Command**: `npm start` (from Frontend/portfolioResume directory)
+- **Technologies**: Angular 19, TypeScript, SCSS, Three.js
+- **Features**:
+  - Server-Side Rendering (SSR)
+  - Multiple themed pages (Kevin's portfolio, Pogoda Software)
+  - Responsive navigation and footer components
+  - Contact forms and project showcases
 
-_Populate as you build_
+### Backend (Django)
+- **Port**: 8000
+- **Start Command**: `python manage.py runserver 0.0.0.0:8000` (from Backend/controller directory)
+- **Technologies**: Django 5.1.5, PostgreSQL, Django REST Framework, Gunicorn
+- **Features**:
+  - REST API endpoints for Pogoda experience and education data
+  - Rate limiting (10 requests/minute) for anti-scraping protection
+  - CORS configuration for frontend integration
+  - Database models for WorkExperience and Education
+  - Management command for seeding database: `python manage.py seed_pogoda_data`
+- **Status**: Fully functional API serving dynamic data from PostgreSQL
 
-## Gotchas
+### Testing
+- **Framework**: Playwright with pytest-bdd
+- **Test Types**: BDD (Behavior-Driven Development) with Gherkin feature files
+- **Coverage**: Home page, About, Experience, Projects, Contact pages
 
-- Neon DB endpoint auto-disables when unused for extended periods. Set `DJANGO_DB=sqlite` (env var) and restart the backend to work around it during dev.
-- Run `playwright install chromium` before running Playwright tests if the browser cache is missing (`.cache/ms-playwright/`).
-- `beauty_session` cookie is HttpOnly + SameSite=Strict; Playwright tests must inject it via `page.context.add_cookies()` rather than JS.
-- `BeautyBusinessDashboardComponent` was a legacy stub — it's been removed. Use `BeautyBusinessHomeComponent` instead.
-- Run Playwright tests from `/home/runner/workspace` (not from `Playwright/`) so the `Playwright.*` module path resolves.
+## Replit Configuration
 
-## Pointers
+### Workflows
+The project uses two workflows:
 
-- Django migrations: `cd Backend/controller && python manage.py migrate`
-- Playwright tests: `cd /home/runner/workspace && BEAUTY_PORT=4200 BACKEND_PORT=8000 python -m pytest Playwright/steps/beauty/ -v`
-- GitHub repo: https://github.com/PogodaSoftware/main_frame
-- PR #57: https://github.com/PogodaSoftware/main_frame/pull/57 (Task #19 — Business Portal v2)
+**Frontend Workflow:**
+- **Name**: `frontend`
+- **Command**: `cd Frontend/portfolioResume && npm start -- --port 5000 --host 0.0.0.0`
+- **Output**: Webview on port 5000
+- **Status**: Running
+
+**Backend Workflow:**
+- **Name**: `backend`
+- **Command**: `cd Backend/controller && python manage.py runserver 0.0.0.0:8000`
+- **Output**: Console (internal API)
+- **Port**: 8000
+- **Status**: Running
+
+### Angular Configuration
+The Angular configuration in `angular.json` remains universal with no hardcoded ports. When running on Replit, port and host are specified via command-line flags in the workflow command to enable Replit's proxy access while keeping the codebase portable for Docker deployment.
+
+### Routes
+**Kevin Ortiz Portfolio:**
+- `/` - Redirects to `/kevin` (home page)
+- `/kevin` - Kevin Ortiz portfolio home
+- `/kevin/about` - About page
+- `/kevin/experience` - Experience page
+- `/kevin/projects` - Projects showcase
+- `/kevin/contacts` - Contact form
+- `/kevin/blender-projects` - Blender projects showcase
+
+**Pogoda Software:**
+- `/pogoda` - Pogoda Software home page
+- `/pogoda/experience` - Professional experience timeline with LinkedIn integration
+
+**Beauty App:**
+- `/pogoda/beauty` - Beauty app main page (service categories + Google Maps)
+- `/pogoda/beauty/signup` - Sign-up page (email + password)
+- `/pogoda/beauty/login` - Customer login page
+- `/pogoda/beauty/business/login` - Business provider login page
+
+## Deployment
+Configured for Replit autoscale deployment:
+- **Build**: `cd Frontend/portfolioResume && npm install && npm run build`
+- **Run**: `cd Frontend/portfolioResume && npx --yes serve dist/portfolio-resume-frontend/browser -l 5000`
+- **Type**: Autoscale (stateless, scales based on traffic)
+- **Note**: Commands navigate to the subdirectory first to handle monorepo structure
+
+## Known Issues
+- WebGL/Three.js features may not work in Replit's browser preview due to lack of WebGL context support in the iframe environment. These features will work when deployed or accessed directly via the public URL.
+- Frontend may initially show fallback data if backend takes time to start (this is expected behavior)
+
+## Backend API Documentation
+
+### Pogoda API Endpoints
+
+**Base URL**: `http://localhost:8000/api/pogoda/`
+
+#### Experience Endpoint
+- **URL**: `/api/pogoda/experience/`
+- **Method**: GET
+- **Authentication**: None (rate limited to 10 requests/minute per IP)
+- **Response**: JSON array of work experience objects
+- **Fields**: id, company, role, period, location, description (array), technologies (array), order
+
+#### Education Endpoint
+- **URL**: `/api/pogoda/education/`
+- **Method**: GET
+- **Authentication**: None (rate limited to 10 requests/minute per IP)
+- **Response**: JSON array of education objects
+- **Fields**: id, institution, degree, period, location, order
+
+### Database Setup
+To set up the database on a fresh deployment:
+```bash
+# Run migrations
+python manage.py migrate
+
+# Seed Pogoda data
+python manage.py seed_pogoda_data
+```
+
+## GitHub Integration & Pull Requests
+
+A reusable skill exists at `.agents/skills/github-pr/SKILL.md` — **always load this skill when the user asks to push to GitHub or create a pull request.**
+
+Key facts:
+- **Token**: `GITHUB_TOKEN` is stored as a Replit secret and is accessible in the shell via `$GITHUB_TOKEN`. Do NOT ask the user for credentials.
+- **Push branch** (token embedded in URL — no git config modification needed):
+  ```bash
+  git push "https://${GITHUB_TOKEN}@github.com/PogodaSoftware/main_frame.git" main:feature/your-branch-name
+  ```
+- **Create PR** (GitHub REST API):
+  ```bash
+  curl -s -X POST \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/PogodaSoftware/main_frame/pulls \
+    -d '{"title":"PR Title","head":"feature/your-branch-name","base":"main","body":"Description"}'
+  ```
+- **Destructive git operations** (`git checkout -b`, `git branch`, `git remote set-url`, `git commit`) are **blocked** in the main agent. Use the URL-embedded token approach above instead.
+- The Replit GitHub OAuth connector flow is **not required** — skip it.
+
+## CI/CD: GitHub → Replit Sync
+A GitHub Actions workflow (`.github/workflows/sync-to-replit.yml`) triggers on every push to `main`. It calls the Replit webhook endpoint which fetches and resets the workspace to match GitHub.
+
+**Webhook endpoint**: `https://<REPLIT_DEV_DOMAIN>:8000/api/deploy/github-sync/`
+- Implemented in `Backend/controller/main_frame_project/deploy_views.py`
+- Protected by `DEPLOY_WEBHOOK_SECRET` environment variable (constant-time comparison)
+
+**Two secrets required in GitHub repo Settings → Secrets → Actions**:
+1. `REPLIT_WEBHOOK_URL` = full URL of the webhook endpoint above
+2. `REPLIT_DEPLOY_SECRET` = value of the `DEPLOY_WEBHOOK_SECRET` Replit secret
+
+**Note**: The `REPLIT_DEV_DOMAIN` URL changes if the Replit environment is reset. Update `REPLIT_WEBHOOK_URL` in GitHub secrets when that happens.
+
+## Future Enhancements
+- Implement backend endpoints for Kevin's contact form
+- Add admin interface for managing experience/education data
+- Integrate additional portfolio projects into database
+- Optional: Integrate LinkedIn API for real-time profile data updates
+- Deploy backend alongside frontend on production

--- a/replit.md
+++ b/replit.md
@@ -1,557 +1,82 @@
 # Portfolio Resume Application
 
-## Architecture: Beauty App Separation (May 2, 2026)
+A full-stack portfolio + beauty booking platform. Kevin Ortiz's portfolio on one side; a beauty marketplace (browse, book, manage) on the other.
 
-The Beauty booking app (`/pogoda/beauty/*`) has been extracted from the portfolio Angular project into its own standalone Angular application to eliminate cross-vulnerability risk.
+## Run & Operate
 
-### Project Structure
-- **`Frontend/portfolioResume/`** — Kevin/Pogoda portfolio (Angular 19, port 5000 in dev)
-- **`Frontend/beautyApp/`** — Beauty booking app (Angular 19 + NgRx, port 4200 in dev)
-- **`Backend/controller/`** — Django BFF (port 8000)
+| Service | Command | Port |
+|---|---|---|
+| Frontend (portfolio) | `ng serve --port 5000` | 5000 |
+| Beauty app | `ng serve --port 4200` | 4200 |
+| Backend | `python manage.py runserver 0.0.0.0:8000` | 8000 |
 
-### How Routing Works
-- In **Docker** (`docker-compose.yml`): the portfolio nginx proxies all `/pogoda/beauty/*` requests to the `beauty_frontend` container (internal port 80). Both apps share the same public-facing port.
-- In **dev** (`Playwright` tests): `FRONTEND_PORT` (default 5000) → portfolio routes; `BEAUTY_PORT` (default 4200) → beauty routes. The `hooks.py` router selects the port automatically by route key.
+**Required env vars / secrets**: `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGPORT` (Neon/PostgreSQL), `SESSION_SECRET`, `GITHUB_TOKEN`.  
+**DB fallback**: set `DJANGO_DB=sqlite` to use SQLite when the Neon endpoint is unavailable (dev only).  
+**After DB reprovisioning**: run `cd Backend/controller && python manage.py migrate`.
 
-### Workflows
-- `frontend` — portfolio Angular dev server on port 5000
-- `beauty` — beauty Angular dev server on port 4200
-- `backend` — Django dev server on port 8000
+## Stack
 
-### Key Files
-| File | Purpose |
-|---|---|
-| `Frontend/beautyApp/src/app/app.routes.ts` | All 26 `/pogoda/beauty/*` routes |
-| `Frontend/beautyApp/src/app/beauty/` | All beauty components, services, guards, store |
-| `Frontend/portfolioResume/nginx.conf` | Proxies `/pogoda/beauty` → `beauty_frontend:80` |
-| `docker-compose.yml` | Added `beauty_frontend` service |
-| `Playwright/Hooks/hooks.py` | Routes beauty test URLs to `BEAUTY_PORT` |
+- **Frontend**: Angular 19 SSR (portfolio, port 5000) + Angular 19 SPA (beauty, port 4200)
+- **Backend**: Django 5.1 + Django REST Framework, BCryptSHA256 password hashing
+- **DB**: PostgreSQL via Neon (Replit-managed); SQLite fallback for dev
+- **Auth**: HttpOnly signed cookie (`beauty_session`) + device-ID binding
+- **Testing**: Playwright + pytest-bdd (in `Playwright/`)
 
-### What Was Removed from Portfolio
-- All files under `src/app/Pogoda-Software-Pages/beauty/` deleted
-- `@ngrx/store` and `@ngrx/effects` removed from `portfolioResume/package.json`
-- Beauty route imports removed from `portfolioResume/src/app/app.routes.ts`
-- `**` wildcard now shows a simple portfolio 404 page instead of `BeautyErrorComponent`
+## Where things live
 
-## Recent Changes (April 18, 2026) — 24-hour Availability + Local-Time Display
-
-Two related improvements so a 24-hour shop (e.g. an all-night hairdresser) and an out-of-town customer both work correctly:
-
-### Backend
-- New `is_24h` BooleanField on `BeautyProviderAvailability` (migration 0007). When true, that day's `start_time`/`end_time` are ignored and the provider is treated as open the full 24 hours.
-- `availability_service`:
-  - `compute_slots()`: 24h days now generate slots from 00:00 to 24:00 UTC (the next day's midnight is used as the close boundary so the last partial slot still fits).
-  - `is_slot_available()`: skips the business-hours window check when the day is marked 24h.
-  - `replace_weekly_hours()`/`get_weekly_hours()`/`_row_to_dict()`: accept and round-trip the new flag, treating closed and 24h as mutually exclusive.
-
-### Frontend
-- New `beauty-time.util.ts` exports `formatSlotLocal(iso)` which renders an ISO timestamp using `Intl.DateTimeFormat` with **no `timeZone`**, so each viewer sees the slot on their own browser clock — exactly what an out-of-town customer needs.
-- `BeautyBookComponent` and `BeautyRescheduleComponent` now show option labels via `slotLabel(o)` instead of the BFF's UTC string.
-- `BeautyBookingDetailComponent` and `BeautyBookingsComponent` now render `formatLocal(b.slot_at)` (with the BFF's `slot_label` as a graceful fallback).
-- `BeautyRescheduleComponent`'s "Currently booked for" card now formats `current_slot_at` locally too.
-- `BeautyBusinessAvailabilityComponent`: new "Open 24h" checkbox per day. Toggling it disables the start/end inputs; toggling Closed clears the 24h flag; the row is round-tripped through the existing PUT.
-
-Smoke-tested: marking a day as 24h yields ~44 bookable 30-min slots for a 60-min service across that UTC day (vs. 15 slots/day on a 10–18 day). Customer-side, all slot pickers and booking screens render in the browser's local timezone with the zone abbreviation appended (e.g. "Mon Apr 20 · 7:00 AM PDT").
-
-## Recent Changes (April 18, 2026) — Customer Booking Reschedule (Task #13)
-
-Customers can now move an existing upcoming booking to a different time without cancelling and rebooking.
-
-### Backend
-- New `RescheduleBookingView` at `POST /api/beauty/protected/bookings/<id>/reschedule/` — validates owner, status (`booked`), and that the booking is still in the future, then runs `is_slot_available()` on the new `slot_at` (excluding this booking's own slot from busy intervals so it doesn't block its own move) and updates the row in place. Returns 400 with a clear `detail` for past slots, conflicts, out-of-hours requests, cancelled or past bookings.
-- `availability_service`: `compute_slots()`, `is_slot_available()`, and `_provider_busy_intervals()` all gained an optional `exclude_booking_id` parameter so the reschedule slot picker shows the booking's current slot among the options.
-
-### BFF
-- New `beauty_reschedule` resolver: customer-only, owner-scoped. Returns the slot picker form (`compute_slots(..., exclude_booking_id=b.id)`) plus `submit_method='POST'`, `submit_href='/api/beauty/protected/bookings/<id>/reschedule/'`, and a `success_route_template` that goes back to the booking-detail screen. Past or non-active bookings short-circuit to a redirect envelope back to `beauty_booking_detail` (with `params={id: b.id}` so the redirect lands on the right URL).
-- `beauty_booking_detail` now exposes a `reschedule` HATEOAS link alongside `cancel` for upcoming bookings.
-- `redirect_envelope()` now accepts an optional `params` kwarg so redirect targets with templated routes (like `/bookings/:id`) get rendered with concrete values.
-- Registered `beauty_reschedule` in `SCREEN_RESOLVERS` and mapped it to `/pogoda/beauty/bookings/:bookingId/reschedule` in `SCREEN_ROUTES`.
-
-### Frontend
-- New standalone `BeautyRescheduleComponent` mirrors the booking flow's slot-picker form, shows the current booked time on a card above the picker, posts the new slot via `BeautyAuthService.follow()`, and on success follows the `booking` link back to the booking-detail screen.
-- `BeautyBookingDetailComponent` now renders a primary "Reschedule" button (when the BFF supplies a `reschedule` link) above the existing Cancel/View Provider buttons.
-- `BeautyShellComponent` imports + templates the new component.
-- `app.routes.ts` registers `/pogoda/beauty/bookings/:bookingId/reschedule` (placed before the `:id` detail route so it matches first), guarded by the existing `beautyAuthGuard`.
-
-End-to-end verified via curl: reschedule link present on upcoming bookings, picker contains the current slot, POST succeeds (10:00 → 12:30), booking-detail shows the new time, the old slot becomes bookable again, past slots / conflicts are rejected with `That slot is no longer available.`, cancelled bookings can no longer be rescheduled and lose the `reschedule` link, and the resolver redirects cleanly back to `beauty_booking_detail` for ineligible bookings.
-
-## Recent Changes (April 18, 2026) — Business Provider Portal + Real Availability (Tasks #14 & #15)
-
-Built the full business provider portal so a signed-in business can manage their storefront end-to-end, and replaced the fixed-slot booking generator with real provider availability.
-
-### Backend
-- New model `BeautyProviderAvailability` (`provider`, `day_of_week`, `start_time`, `end_time`, `is_closed`) with a unique `(provider, day_of_week)` constraint. Migration `0006_beauty_provider_availability` creates the table and seeds Mon-Sat 10-18 / Sunday closed for every existing `BeautyProvider`.
-- New `beauty_api/availability_service.py` exposes `get_weekly_hours(provider)` (always 7 rows, auto-creates defaults), `replace_weekly_hours(provider, rows)` (validates + bulk replaces), `compute_slots(service, days_ahead=14)` (steps every 30 min within open hours, skips closed days, skips slots that overlap any existing booking on the same provider, drops past slots), `is_slot_available(service, slot_at)` (server-side validation), and `ensure_storefront(business_provider)` (idempotent storefront bootstrap).
-- New `beauty_api/business_views.py` adds the protected REST surface under `/api/beauty/protected/business/`: `dashboard/` (stats), `services/` GET+POST, `services/<id>/` PUT+DELETE, `availability/` GET+PUT, `bookings/` GET. All handlers reject non-business cookies with 403; future bookings on a deleted service are auto-cancelled before delete.
-- `BusinessLoginView` calls `ensure_storefront()` on every login so a freshly signed-up business has a working storefront with default weekly hours.
-- `booking_views.py` POST now calls `is_slot_available()` so the customer flow respects business hours and overlapping bookings.
-
-### BFF
-- `beauty_book.py` slot list now comes from `compute_slots()` (the fixed `SLOT_HOURS` generator is gone).
-- `beauty_business_login.py` redirects already-signed-in business users to `beauty_business_home` and uses that as its post-login `success_screen`.
-- `beauty_home.py` shows a "Business Portal" link to authenticated business users.
-- 5 new resolvers: `beauty_business_home` (dashboard), `beauty_business_services` (list with edit/delete links), `beauty_business_service_form` (single screen for add+edit, `serviceId=='new'` ⇒ add), `beauty_business_availability` (7-row editor with PUT submit metadata), `beauty_business_bookings` (upcoming/past split).
-- `SCREEN_ROUTES` and `SCREEN_RESOLVERS` registered for all 5 new screens.
-
-### Frontend
-- 5 new standalone Angular components in `src/app/Pogoda-Software-Pages/beauty/`: `beauty-business-dashboard`, `beauty-business-services`, `beauty-business-service-form`, `beauty-business-availability`, `beauty-business-bookings`. All consume `data` + `_links` props and emit `followLink` events the shell handles.
-- `BeautyShellComponent` imports + templates the 5 components and adds them to its screen→route fallback map.
-- `app.routes.ts` adds 6 new routes (one per screen, plus a separate `services/new` route for the add-service form), all guarded by `beautyBusinessAuthGuard`.
-
-## Recent Changes (April 18, 2026) — Runtime Beauty Feature-Flag Admin (Task #8)
-
-Added a small admin screen at `/pogoda/beauty/admin/flags` that lets an authenticated user toggle Beauty BFF feature flags at runtime. Toggles take effect on the very next BFF resolve — no Angular rebuild and no Django restart required.
-
-**Backend:**
-- New models in `beauty_api/models.py`:
-  - `BeautyFeatureFlag` (`key`, `enabled`, `description`, `updated_at`, `updated_by_*`) — the runtime source of truth.
-  - `BeautyFlagAudit` (`flag_key`, `old_value`, `new_value`, `changed_by_*`, `changed_at`) — append-only audit trail.
-  - Migration `0003_beautyfeatureflag_beautyflagaudit.py` creates both tables and seeds default rows for existing flags.
-- `bff_api/services/hateoas_service.py` — `is_business_login_enabled()` / `is_signup_enabled()` now consult the `beauty_feature_flags` table first and fall back to the legacy env-var defaults if the row is missing or the DB is unavailable. New `FEATURE_FLAGS` registry declares every known flag (key, label, description, default) so the admin screen iterates one list. Added `beauty_admin_flags` to `SCREEN_ROUTES`.
-- New resolver `bff_api/resolvers/beauty_admin_flags.py` — auth-required, lists each registered flag with current value + a `toggle` link, plus the 25 most recent audit entries.
-- New endpoint `POST /api/beauty/admin/flags/toggle/` (`beauty_api/admin_views.py`, wired in `beauty_api/urls.py`) — validates the flag key against the registry, upserts the row inside a transaction, writes an audit row, returns the new value.
-- **Authorisation:** both the resolver and the toggle endpoint require the caller's `(user_type, user_id)` pair to appear in the `BEAUTY_ADMIN_PRINCIPALS` env var (comma-separated `<user_type>:<user_id>` pairs, e.g. `customer:1,business:7`). We bind to the stable PK identity rather than email because `BeautyUser` and `BusinessProvider` are independent tables with no cross-table email uniqueness — using email would let a duplicate-email registration in the other table escalate to admin. Authenticated non-admins get 403 from the endpoint and a redirect to `beauty_home` (`reason: forbidden`) from the resolver. The default (no admins) means the surface is locked down until an operator opts in. Helpers: `hateoas_service.is_beauty_admin(user)` and `_admin_principal_allowlist()`.
-
-**Frontend:**
-- New presentational component `beauty-admin-flags.component.ts` — renders the flag list with iOS-style toggle switches and a chronological audit log.
-- `BeautyShellComponent` registers the new screen, holds admin state (`adminFlags`, `adminAudit`, `adminEmail`, `busyFlagKey`), and forwards toggle clicks through `BeautyAuthService.follow(toggle_link, {key, enabled})`. After each successful toggle the shell re-resolves so the new value and the new audit entry appear immediately.
-- New Angular route `/pogoda/beauty/admin/flags` → `BeautyShellComponent` with `data: { screen: 'beauty_admin_flags' }`. Added matching entry to the shell's screen→route fallback map.
-
-**Verified end-to-end:**
-- Resolver returns the flag list with toggle links (200).
-- Toggling `BEAUTY_SIGNUP_ENABLED` off via the API immediately removes the `signup` link from `beauty_home`'s `_links` envelope on the very next resolve, with no restart.
-- Audit entry recorded with the actor's email and user type.
-- Bad flag key → 400; unauthenticated request → 401.
-
-## Recent Changes (April 18, 2026) — HATEOAS + Dynamic Form Schema for Beauty BFF (Task #6)
-
-### What changed — "over-the-air" UI updates
-
-The Beauty BFF was upgraded from a fixed render contract into a fully **hypermedia-driven** one. The Angular shell no longer hardcodes endpoint URLs, screen-to-route mappings, form field lists, or which footer links to show. The backend dictates all of it via a `_links` envelope and a `form` schema, so adding a field, hiding an action via a feature flag, or rerouting a flow ships **without an Angular release**.
-
-**Backend:**
-- `Backend/controller/bff_api/services/hateoas_service.py` — link builders (`link`, `screen_link`, `self_link`), the `SCREEN_ROUTES` map (server is sole source of truth for route paths), form schema builders (`login_form`, `signup_form`, `email_field`, `password_field`, `footer_link`), and feature-flag helpers (`is_business_login_enabled`, `is_signup_enabled`) driven by env vars `BEAUTY_BUSINESS_LOGIN_ENABLED` and `BEAUTY_SIGNUP_ENABLED`.
-- All 8 resolvers refactored to emit a HATEOAS envelope: every render carries `_links: {rel: link_obj}`, every redirect carries `_links.target`. Login/signup/business-login resolvers also emit a full `form` schema (fields, validators, submit href + method, success link, footer links, presentation classes, error messages).
-- Legacy fields (`redirect_to` string, `data.links` screen-name dict) are kept alongside the new envelope so existing tests pass.
-- `bff_api/views.py` bumped `APP_VERSION` to `2.0.0`; registered all 8 resolvers including `beauty_business_providers` and `beauty_sessions`.
-
-**Frontend:**
-- `beauty-bff.types.ts` — shared `BffLink`, `BffFieldSchema`, `BffFormSchema`, `BffResponse` types.
-- `BeautyAuthService` no longer hardcodes login/signup/business/logout URLs. Generic `follow(link, body, includeDeviceId)` posts to whatever URL the BFF supplies, on whatever HTTP method the link declares.
-- `BeautyDynamicFormComponent` — schema-driven form renderer. Iterates the schema's fields, validators, and footer links; preserves all existing CSS classes via the schema's `presentation` block so Playwright selectors remain stable.
-- `BeautyShellComponent` — dropped the local `SCREEN_TO_ROUTE` table. Navigation comes from `link.route`. Handles render and redirect responses; on `(followLink)` events fires the link's HTTP method (or just navigates for `method=NAV`) and re-resolves.
-- `BeautyLoginComponent`, `BeautySignupComponent`, `BeautyBusinessLoginComponent` reduced to thin wrappers around the dynamic form.
-- `BeautyMainComponent` builds its header buttons from the `_links` map (rels `login`, `signup`, `business_login`, `logout`); every CTA emits `(followLink)` with the original `BffLink`.
-
-### Envelope contract (v2.0.0)
-```jsonc
-{
-  "action": "render" | "redirect",
-  "screen": "beauty_login",
-  "data":   { ... },
-  "meta":   { "title": "..." },
-  "_links": {
-    "self":   { "rel": "...", "href": "...", "method": "NAV|GET|POST|...", "screen": "...", "route": "/...", "prompt": "..." },
-    "logout": { ... },
-    "target": { ... }   // only on action=redirect
-  },
-  "form": {              // only on screens that render a form
-    "title": "...",
-    "fields": [{ "name", "type", "label", "placeholder", "required", "min_length", "secret_toggle", "error_messages" }],
-    "submit": <link>,
-    "success": <link>,
-    "presentation": { "page_class", "form_class", "submit_class", ... },
-    "footer_links": [{ "rel", "cta_class", "group_class", "label_prefix" }],
-    "error_status_map": { "401": "..." },
-    "error_default": "..."
-  },
-  "redirect_to": "beauty_login",   // legacy, only on action=redirect
-  "app_version": "2.0.0",
-  "needs_update": false
-}
+```
+Frontend/portfolioResume/   Kevin/Pogoda portfolio (Angular 19)
+Frontend/beautyApp/         Beauty SPA (Angular 19)
+  src/app/beauty/           All beauty components, guards, services
+  src/app/app.routes.ts     All /pogoda/beauty/* routes (business + customer)
+Backend/controller/
+  beauty_api/               Models, views, middleware, migrations
+  bff_api/                  BFF resolvers, HATEOAS service, screen registry
+  main_frame_project/       Django settings, URLs
+Playwright/
+  features/Pogoda/Beauty/   BDD feature files
+  steps/beauty/             Step implementations + page objects
+  Hooks/hooks.py            Route→URL mapping for test runner
+docker-compose.yml          Wires all three services + nginx proxy
 ```
 
----
+Source-of-truth files: `beauty_api/models.py` (DB schema), `bff_api/services/hateoas_service.py` (SCREEN_ROUTES), `app.routes.ts` (Angular routes).
 
-## Recent Changes (April 1, 2026) — BFF SDUI Architecture for Beauty App (PR #43)
+## Architecture decisions
 
-### What changed
-Implemented a complete **Server-Driven UI (SDUI) / Backend-for-Frontend (BFF)** layer for all `/pogoda/beauty/*` routes. The Angular shell now stores **nothing** — it queries the backend on every navigation and renders exactly what the server instructs.
+- **SDUI / BFF pattern**: Angular shell POSTs `{screen, device_id}` to `/api/bff/beauty/resolve/` on every navigation. BFF returns `{action, screen, data, _links, form}` — no hardcoded URLs, route paths, or form fields in the frontend.
+- **Beauty app separation**: Beauty lives in its own Angular project (`beautyApp/`) to isolate its NgRx/feature dependencies from the portfolio. In Docker, nginx proxies `/pogoda/beauty/*` to the beauty container.
+- **Hypermedia links**: All navigation, form submit URLs, and feature-flag visibility come from `_links` in the BFF envelope (HATEOAS). Adding a new action requires only a BFF change.
+- **Application gate**: `application_gate.py` enforces that a business must complete the 6-step onboarding wizard before any portal screen resolves. All business resolvers call it first.
+- **SQLite fallback**: `settings.py` checks `DJANGO_DB=sqlite` so the backend can start without a live Neon endpoint (set automatically via env var).
 
-**Backend — new `bff_api` Django app:**
-- `POST /api/bff/beauty/resolve/` — single entry point for the Angular shell
-- **Microservices:** `auth_service.py` (cookie + device_id validation) and `beauty_config_service.py` (static config)
-- **Screen resolvers:** `beauty_home`, `beauty_login`, `beauty_signup`, `beauty_business_login` — each runs independently, can be unit-tested in isolation
-- Returns `{action: "render" | "redirect", screen, data, meta}` — shell renders what BFF says
-- Registered in `INSTALLED_APPS` and `urls.py` at `/api/bff/`
+## Product
 
-**Frontend:**
-- `BeautyBffService` — POSTs `{version, screen, device_id}` to resolve endpoint
-- `BeautyShellComponent` — SDUI orchestrator; reads screen from route `data`, re-resolves on every navigation, renders child from BFF response, handles events
-- All four beauty components refactored to **presentational** (accept `@Input() data`, emit `@Output()` events, no localStorage, no Router)
-- `app.routes.ts` — all four beauty paths now point to `BeautyShellComponent` with `data: {screen}`
+**Customer side** (`/pogoda/beauty/*`):
+- Browse beauty providers by category, view profiles, book slots, manage bookings, reschedule, cancel, chat with provider.
 
-**Pull Request:** https://github.com/PogodaSoftware/main_frame/pull/43
+**Business side** (`/pogoda/beauty/business/*`):
+- Sign up → 6-step onboarding wizard (entity/ITIN, services, Stripe stub, weekly hours, tools, ToS review) → portal unlocks.
+- Home dashboard: scrollable month calendar of bookings, earnings arc gauge, bookings-volume card (new vs recurring).
+- Manage services (CRUD), weekly availability, incoming bookings, settings/password/profile.
 
----
+**Admin** (`/pogoda/beauty/admin/flags`): runtime feature-flag toggle (BEAUTY_SIGNUP_ENABLED, BEAUTY_BUSINESS_LOGIN_ENABLED) with audit trail.
 
-## Recent Changes (March 31, 2026) — bcrypt Password Hashing
-- Replaced Django's default PBKDF2 hasher with **BCryptSHA256PasswordHasher**
-- Added `bcrypt==4.2.1` to `requirements.txt`
-- Configured `PASSWORD_HASHERS` in `settings.py` — bcrypt is primary, PBKDF2 kept as fallback for any existing rows
-- `make_password()` and `check_password()` in models and views use bcrypt automatically — no other code changes needed
-- SHA-256 pre-hashing removes bcrypt's 72-byte input limit
-- Password fields carry **no unique constraint**; only email fields are unique
-- Pull Request: https://github.com/PogodaSoftware/main_frame/pull/42
+## User preferences
 
----
+_Populate as you build_
 
-## Recent Changes (March 31, 2026) — Auth Middleware
-- **Beauty Auth Middleware (`beauty_api/middleware.py`):**
-  - `BeautyAuthMiddleware` intercepts all `/api/beauty/protected/*` routes
-  - Validates a Django-signed HttpOnly cookie (`beauty_auth`) — tamper-proof and expiry-checked
-  - Confirms `device_id` inside the cookie matches the `X-Device-ID` request header
-  - Verifies the session record is still active in the DB
-  - Returns HTTP 401 on any failure; Angular guard redirects to login page
-  - Multiple devices stay independent — each gets its own cookie/session
+## Gotchas
 
-- **New DB models (migration 0002):**
-  - `BeautySession` — tracks (user_id, user_type, device_id, token_hash, expires_at, is_active)
-  - `BusinessProvider` — email, hashed password, business_name
+- Neon DB endpoint auto-disables when unused for extended periods. Set `DJANGO_DB=sqlite` (env var) and restart the backend to work around it during dev.
+- Run `playwright install chromium` before running Playwright tests if the browser cache is missing (`.cache/ms-playwright/`).
+- `beauty_session` cookie is HttpOnly + SameSite=Strict; Playwright tests must inject it via `page.context.add_cookies()` rather than JS.
+- `BeautyBusinessDashboardComponent` was a legacy stub — it's been removed. Use `BeautyBusinessHomeComponent` instead.
+- Run Playwright tests from `/home/runner/workspace` (not from `Playwright/`) so the `Playwright.*` module path resolves.
 
-- **New API endpoints:**
-  - `POST /api/beauty/login/` — issues 24-hour HttpOnly SameSite=Strict cookie
-  - `POST /api/beauty/logout/` — invalidates session, clears cookie
-  - `POST /api/beauty/business/login/` and `/business/logout/` — business provider flow
-  - `GET  /api/beauty/protected/me/` — returns current user info; used by Angular auth guard
+## Pointers
 
-- **Angular auth (Frontend):**
-  - `BeautyAuthService` — generates persistent device fingerprint (localStorage), sends `X-Device-ID` header
-  - `beautyAuthGuard` and `beautyBusinessAuthGuard` functional route guards
-  - `BeautyLoginComponent` at `/pogoda/beauty/login` (email + password)
-  - `BeautyBusinessLoginComponent` at `/pogoda/beauty/business/login`
-  - Beauty main page header now shows "Sign in" + "Sign up" buttons when logged out
-
-- **Security measures applied:**
-  - HttpOnly cookie — JS cannot read the token (XSS-proof)
-  - SameSite=Strict — cookie never sent on cross-site requests (CSRF-proof)
-  - Secure flag — HTTPS only in production
-  - Django signed token — built-in expiry, tamper-proof
-  - SHA-256 token hash — raw token never stored in DB
-  - Device ID binding — request must match the device the token was issued for
-  - Generic 401 errors — no user enumeration possible
-  - Constant-time `check_password` — prevents timing attacks
-
-- **Pull Request:** https://github.com/PogodaSoftware/main_frame/pull/41
-
----
-
-## Recent Changes (March 31, 2026) — Beauty App Pages (Mobile-first)
-- Created two new pages under `/pogoda/beauty` and `/pogoda/beauty/signup`
-  - Mobile-first design (iPhone 16/17 393px, Samsung S25 390px, Pixel 9 412px, iPhone 17 Plus 430px)
-  - Main page: dark header with "Beauty" brand + Sign up button, horizontal scrollable service row (Beauty, Lashes, Nails, Makeup), Google Maps placeholder (ready for API key)
-  - Sign-up page: email + password form with validation, show/hide password toggle, loading state
-  - After sign-up, user email saved to localStorage and displayed in header
-  - Google Maps: loads dynamically when `googleMapsApiKey` is set in `src/environments/environment.ts`
-  
-- **Django: beauty_api app:**
-  - New `BeautyUser` model (email, hashed password, created_at) in `beauty_api` app
-  - `POST /api/beauty/signup/` endpoint with email uniqueness and password length validation
-  - Uses Django's built-in password hashing (`make_password`)
-  - Migration applied to PostgreSQL database
-
-- **Angular: @angular/forms added:**
-  - Installed `@angular/forms@19.2.15` for template-driven forms in sign-up page
-
-- **Environment files created:**
-  - `src/environments/environment.ts` (dev) and `src/environments/environment.prod.ts` (prod)
-  - Contains `googleMapsApiKey` (empty by default) and `apiBaseUrl`
-  - angular.json configured with fileReplacements for prod build
-
-## Recent Changes (November 13, 2025)
-- **Pogoda Software - Complete Separation from Kevin's Portfolio**:
-  - Removed all links to Kevin's portfolio from Pogoda navigation (desktop and mobile)
-  - Removed "Kevin's Portfolio" button from Pogoda home page
-  - Pogoda Software section now operates completely independently
-  - Navigation shows only: Home and Experience
-  
-- **PostgreSQL Backend Integration for Pogoda Software**:
-  - **Database**: Created PostgreSQL database with WorkExperience and Education models
-  - **Django REST API**: Built API endpoints at `/api/pogoda/experience/` and `/api/pogoda/education/`
-  - **Anti-Scraping Protection**: Implemented rate limiting (10 requests/minute per IP) using DRF throttling
-  - **Data Migration**: Database seeded with 6 work experiences and 2 education entries from Jaroslaw Pogoda's LinkedIn
-  - **Angular Integration**: Created HTTP service to fetch data dynamically from backend API
-  - **SSR Compatibility**: Added platform detection to only make API calls in browser (not during SSR)
-  - **Fallback System**: Component falls back to static data if API is unavailable for reliability
-  - **CORS Configuration**: Configured CORS to allow frontend access while maintaining security
-  - **Workflows**: Both backend (port 8000) and frontend (port 5000) running successfully
-  
-- **Pogoda Experience Page - Real LinkedIn Data**:
-  - Populated experience page with Jaroslaw Pogoda's actual LinkedIn professional history
-  - Added 6 work experiences: Gesture (current), Per Scholas, Sprint, Azodio.com, Bellevue Hospital, Freelance IT
-  - Updated education with Queens College BS in Computer Science (2010-2016) and Triplebyte certification (2022)
-  - All job descriptions, technologies, dates, and locations now reflect real professional background
-  - Experience extracted from public LinkedIn profile via web search (LinkedIn direct fetch not supported)
-  - Data dynamically loaded from PostgreSQL database via REST API
-
-## Recent Changes (November 12, 2025)
-- **New Pogoda Software Pages**:
-  - Created complete Pogoda Software section with professional experience display
-  - Added navigation and footer components for Pogoda pages
-  - Created `/pogoda` home page with LinkedIn integration
-  - Created `/pogoda/experience` page with professional timeline layout
-  - Modern card-based design with technology tags and timeline visualization
-  
-- **Major Security Upgrade & Dependency Cleanup**:
-  - Angular: Upgraded from 19.0.0 to 19.2.15 (fixed high severity SSR vulnerability)
-  - All packages updated to latest secure versions
-  - **0 security vulnerabilities** remaining (verified with npm audit)
-  
-- **Dependency Reduction**:
-  - **Removed unused frontend dependencies**: @angular/forms, @angular/animations, portfolio-resume-frontend self-reference
-  - **Removed unused dev dependencies**: Karma, Jasmine testing framework (using Playwright for E2E)
-  - **Removed unused backend dependencies**: behave (using pytest-bdd instead)
-  - **Result**: Reduced package count from 1157 to 849 packages (-27% reduction)
-  
-- **Code Cleanup**:
-  - Removed all unused Jasmine/Karma test files (.spec.ts files)
-  - Removed karma.conf.js and test configuration directory
-  - Removed unused backend unit test examples
-  - **Result**: Smaller, more maintainable codebase
-  
-- **SSR Fixes**:
-  - Updated main.server.ts to support Angular 19.2.x SSR API changes (BootstrapContext)
-  - Fixed NG0401 error by properly passing bootstrap context
-  - THREE.js platform detection maintained for browser-only rendering
-  
-- **Bug Fixes from Previous Session** (November 6, 2025):
-  - Added favicon.svg to resolve 404 error in browser console
-  - Fixed SSR compatibility issue with THREE.js by adding platform detection
-  - Ensured browser-specific code only runs in browser context
-  
-- **Verification**: All core functionality tested and working properly
-  - Frontend: Angular 19.2.15 SSR working correctly
-  - Backend: Django 5.1.5 running without issues
-  - Navigation: All routes functioning properly
-  - 3D models: Platform detection prevents SSR errors
-  - Security: 0 vulnerabilities in production and dev dependencies
-
-## Overview
-This is a full-stack portfolio and resume application featuring:
-- **Frontend**: Angular 19 application with Server-Side Rendering (SSR)
-- **Backend**: Django 5.1.5 REST API (currently minimal setup)
-- **Testing**: Playwright-based end-to-end testing suite
-
-The application showcases Kevin Ortiz's portfolio as a Quality Assurance & DevOps Engineer, with sections for About, Experience, Projects, and Contact information.
-
-## Running the Application
-
-This project supports two deployment approaches:
-
-### Option 1: Docker (Universal - Recommended for Local Development)
-The original Docker-based setup works on any system with Docker installed:
-
-```bash
-# Set environment variables
-export FRONTEND_PORT=4200
-export BACKEND_PORT=8000
-
-# Run with docker-compose
-docker-compose up
-```
-
-The application will be available at:
-- Frontend: http://localhost:4200
-- Backend: http://localhost:8000
-
-### Option 2: Replit (Cloud Development)
-On Replit, Docker is not supported. Instead, the application runs natively:
-
-**Frontend**: 
-```bash
-cd Frontend/portfolioResume
-npm start -- --port 5000 --host 0.0.0.0
-```
-
-**Backend**:
-```bash
-cd Backend/controller
-python manage.py runserver 0.0.0.0:8000
-```
-
-**Note**: The Angular configuration in `angular.json` is kept universal (no hardcoded ports). Port and host are specified via command-line arguments passed through npm to the Angular dev server in the Replit workflow.
-
-## Project Structure
-```
-.
-├── Frontend/portfolioResume/     # Angular 19 frontend application
-│   ├── src/
-│   │   ├── app/
-│   │   │   ├── Kevin-Pages/      # Main portfolio pages
-│   │   │   └── Pogoda-Software-Pages/
-│   │   └── assets/               # Static assets
-│   ├── angular.json              # Angular configuration
-│   └── package.json              # Frontend dependencies
-├── Backend/controller/           # Django backend
-│   ├── main_frame_project/
-│   ├── requirements.txt          # Python dependencies
-│   └── manage.py
-└── Playwright/                   # E2E test suite
-    ├── features/                 # BDD feature files
-    ├── pages/                    # Page object models
-    └── steps/                    # Test step definitions
-```
-
-## Development Setup
-
-### Frontend (Angular)
-- **Port**: 5000 (configured for Replit)
-- **Host**: 0.0.0.0 (allows Replit proxy access)
-- **Start Command**: `npm start` (from Frontend/portfolioResume directory)
-- **Technologies**: Angular 19, TypeScript, SCSS, Three.js
-- **Features**:
-  - Server-Side Rendering (SSR)
-  - Multiple themed pages (Kevin's portfolio, Pogoda Software)
-  - Responsive navigation and footer components
-  - Contact forms and project showcases
-
-### Backend (Django)
-- **Port**: 8000
-- **Start Command**: `python manage.py runserver 0.0.0.0:8000` (from Backend/controller directory)
-- **Technologies**: Django 5.1.5, PostgreSQL, Django REST Framework, Gunicorn
-- **Features**:
-  - REST API endpoints for Pogoda experience and education data
-  - Rate limiting (10 requests/minute) for anti-scraping protection
-  - CORS configuration for frontend integration
-  - Database models for WorkExperience and Education
-  - Management command for seeding database: `python manage.py seed_pogoda_data`
-- **Status**: Fully functional API serving dynamic data from PostgreSQL
-
-### Testing
-- **Framework**: Playwright with pytest-bdd
-- **Test Types**: BDD (Behavior-Driven Development) with Gherkin feature files
-- **Coverage**: Home page, About, Experience, Projects, Contact pages
-
-## Replit Configuration
-
-### Workflows
-The project uses two workflows:
-
-**Frontend Workflow:**
-- **Name**: `frontend`
-- **Command**: `cd Frontend/portfolioResume && npm start -- --port 5000 --host 0.0.0.0`
-- **Output**: Webview on port 5000
-- **Status**: Running
-
-**Backend Workflow:**
-- **Name**: `backend`
-- **Command**: `cd Backend/controller && python manage.py runserver 0.0.0.0:8000`
-- **Output**: Console (internal API)
-- **Port**: 8000
-- **Status**: Running
-
-### Angular Configuration
-The Angular configuration in `angular.json` remains universal with no hardcoded ports. When running on Replit, port and host are specified via command-line flags in the workflow command to enable Replit's proxy access while keeping the codebase portable for Docker deployment.
-
-### Routes
-**Kevin Ortiz Portfolio:**
-- `/` - Redirects to `/kevin` (home page)
-- `/kevin` - Kevin Ortiz portfolio home
-- `/kevin/about` - About page
-- `/kevin/experience` - Experience page
-- `/kevin/projects` - Projects showcase
-- `/kevin/contacts` - Contact form
-- `/kevin/blender-projects` - Blender projects showcase
-
-**Pogoda Software:**
-- `/pogoda` - Pogoda Software home page
-- `/pogoda/experience` - Professional experience timeline with LinkedIn integration
-
-**Beauty App:**
-- `/pogoda/beauty` - Beauty app main page (service categories + Google Maps)
-- `/pogoda/beauty/signup` - Sign-up page (email + password)
-- `/pogoda/beauty/login` - Customer login page
-- `/pogoda/beauty/business/login` - Business provider login page
-
-## Deployment
-Configured for Replit autoscale deployment:
-- **Build**: `cd Frontend/portfolioResume && npm install && npm run build`
-- **Run**: `cd Frontend/portfolioResume && npx --yes serve dist/portfolio-resume-frontend/browser -l 5000`
-- **Type**: Autoscale (stateless, scales based on traffic)
-- **Note**: Commands navigate to the subdirectory first to handle monorepo structure
-
-## Known Issues
-- WebGL/Three.js features may not work in Replit's browser preview due to lack of WebGL context support in the iframe environment. These features will work when deployed or accessed directly via the public URL.
-- Frontend may initially show fallback data if backend takes time to start (this is expected behavior)
-
-## Backend API Documentation
-
-### Pogoda API Endpoints
-
-**Base URL**: `http://localhost:8000/api/pogoda/`
-
-#### Experience Endpoint
-- **URL**: `/api/pogoda/experience/`
-- **Method**: GET
-- **Authentication**: None (rate limited to 10 requests/minute per IP)
-- **Response**: JSON array of work experience objects
-- **Fields**: id, company, role, period, location, description (array), technologies (array), order
-
-#### Education Endpoint
-- **URL**: `/api/pogoda/education/`
-- **Method**: GET
-- **Authentication**: None (rate limited to 10 requests/minute per IP)
-- **Response**: JSON array of education objects
-- **Fields**: id, institution, degree, period, location, order
-
-### Database Setup
-To set up the database on a fresh deployment:
-```bash
-# Run migrations
-python manage.py migrate
-
-# Seed Pogoda data
-python manage.py seed_pogoda_data
-```
-
-## GitHub Integration & Pull Requests
-
-A reusable skill exists at `.agents/skills/github-pr/SKILL.md` — **always load this skill when the user asks to push to GitHub or create a pull request.**
-
-Key facts:
-- **Token**: `GITHUB_TOKEN` is stored as a Replit secret and is accessible in the shell via `$GITHUB_TOKEN`. Do NOT ask the user for credentials.
-- **Push branch** (token embedded in URL — no git config modification needed):
-  ```bash
-  git push "https://${GITHUB_TOKEN}@github.com/PogodaSoftware/main_frame.git" main:feature/your-branch-name
-  ```
-- **Create PR** (GitHub REST API):
-  ```bash
-  curl -s -X POST \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/PogodaSoftware/main_frame/pulls \
-    -d '{"title":"PR Title","head":"feature/your-branch-name","base":"main","body":"Description"}'
-  ```
-- **Destructive git operations** (`git checkout -b`, `git branch`, `git remote set-url`, `git commit`) are **blocked** in the main agent. Use the URL-embedded token approach above instead.
-- The Replit GitHub OAuth connector flow is **not required** — skip it.
-
-## CI/CD: GitHub → Replit Sync
-A GitHub Actions workflow (`.github/workflows/sync-to-replit.yml`) triggers on every push to `main`. It calls the Replit webhook endpoint which fetches and resets the workspace to match GitHub.
-
-**Webhook endpoint**: `https://<REPLIT_DEV_DOMAIN>:8000/api/deploy/github-sync/`
-- Implemented in `Backend/controller/main_frame_project/deploy_views.py`
-- Protected by `DEPLOY_WEBHOOK_SECRET` environment variable (constant-time comparison)
-
-**Two secrets required in GitHub repo Settings → Secrets → Actions**:
-1. `REPLIT_WEBHOOK_URL` = full URL of the webhook endpoint above
-2. `REPLIT_DEPLOY_SECRET` = value of the `DEPLOY_WEBHOOK_SECRET` Replit secret
-
-**Note**: The `REPLIT_DEV_DOMAIN` URL changes if the Replit environment is reset. Update `REPLIT_WEBHOOK_URL` in GitHub secrets when that happens.
-
-## Future Enhancements
-- Implement backend endpoints for Kevin's contact form
-- Add admin interface for managing experience/education data
-- Integrate additional portfolio projects into database
-- Optional: Integrate LinkedIn API for real-time profile data updates
-- Deploy backend alongside frontend on production
+- Django migrations: `cd Backend/controller && python manage.py migrate`
+- Playwright tests: `cd /home/runner/workspace && BEAUTY_PORT=4200 BACKEND_PORT=8000 python -m pytest Playwright/steps/beauty/ -v`
+- GitHub repo: https://github.com/PogodaSoftware/main_frame
+- PR #57: https://github.com/PogodaSoftware/main_frame/pull/57 (Task #19 — Business Portal v2)

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const path = require('path');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+const PORTFOLIO_DIR = path.join(__dirname, 'Frontend/portfolioResume/dist/portfolio-resume-frontend/browser');
+const BEAUTY_DIR = path.join(__dirname, 'Frontend/beautyApp/dist/beauty-app/browser');
+
+app.use('/api', createProxyMiddleware({
+  target: BACKEND_URL,
+  changeOrigin: true,
+  on: {
+    error: (err, req, res) => {
+      console.error('Proxy error:', err.message);
+      res.status(502).json({ error: 'Backend unavailable' });
+    }
+  }
+}));
+
+app.use('/pogoda/beauty', express.static(BEAUTY_DIR));
+
+app.get(['/pogoda/beauty', '/pogoda/beauty/*'], (req, res) => {
+  res.sendFile(path.join(BEAUTY_DIR, 'index.html'));
+});
+
+app.use('/kevin', express.static(PORTFOLIO_DIR));
+
+app.get(['/kevin', '/kevin/*'], (req, res) => {
+  res.sendFile(path.join(PORTFOLIO_DIR, 'index.html'));
+});
+
+app.use(express.static(PORTFOLIO_DIR));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(PORTFOLIO_DIR, 'index.html'));
+});
+
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Unified server running on port ${PORT}`);
+  console.log(`  Portfolio → ${PORTFOLIO_DIR}`);
+  console.log(`  Beauty    → ${BEAUTY_DIR}`);
+  console.log(`  API proxy → ${BACKEND_URL}`);
+});

--- a/server.js
+++ b/server.js
@@ -15,7 +15,9 @@ app.use('/api', createProxyMiddleware({
   on: {
     error: (err, req, res) => {
       console.error('Proxy error:', err.message);
-      res.status(502).json({ error: 'Backend unavailable' });
+      if (!res.headersSent) {
+        res.status(502).end();
+      }
     }
   }
 }));


### PR DESCRIPTION
## Summary

Two related tasks bundled together.

---

### Task #30 — Selective pull: 4 files from origin/main (PRs #54–57)

Applies content of 4 files from the remote main branch while keeping all local work (Admin CRM, Playwright tests, deployment config) intact.

- **`replit.md`** — replaced with the expanded remote version documenting the full architecture (beauty app separation, HATEOAS, availability, reschedule, business portal, feature flags, CI/CD).
- **`Frontend/beautyApp/angular.json`** — exact remote: removes `serve.options.servePath` block (3 lines).
- **`Frontend/beautyApp/src/app/beauty/beauty-shell.component.ts`** — additive from remote: added `BeautyBusinessDashboardComponent` import and `@Component` imports entry. Local `[links]` and `(followLink)` bindings on `app-beauty-admin-flags` preserved (Task #22).
- **`Backend/controller/bff_api/services/hateoas_service.py`** — remote BFF routing changes applied; local DEBUG-gated `/tmp` override retained at the time (superseded by Task #31).

---

### Task #31 — Replace /tmp file admin override with DB-backed `BeautyAdminPrincipal`

Replaces the fragile `/tmp` file approach for granting admin access in tests with a proper DB-backed model.

**Backend:**
- New `BeautyAdminPrincipal` model (`beauty_admin_principals` table) with unique `(user_type, user_id)` constraint — same pattern as `BeautyFeatureFlag`.
- Migration `0014_beauty_admin_principal` — created and applied.
- `hateoas_service._admin_principal_allowlist()` now reads from both the `BEAUTY_ADMIN_PRINCIPALS` env var and the DB table. DB exceptions are logged via `logger.warning`. Removed unused `from django.conf import settings` import. No `/tmp` references remain.

**Playwright tests (`test_beauty_admin_crm.py`):**
- `_shell()` raises `RuntimeError` on non-zero exit or stderr so seeding failures surface immediately.
- `_set_admin_principal()` inserts a `BeautyAdminPrincipal` row via `_shell()`.
- `_clear_admin_principal()` deletes the row; signature updated to `(user_type, user_id)`.
- `beauty_admin` fixture passes both args to the updated cleanup.
- No `/tmp` file references remain anywhere.

**Dev server fix:**
- Added `servePath: "/pogoda/beauty/"` to `Frontend/beautyApp/angular.json` serve options so the beauty dev server serves assets at the correct base path for Playwright tests.

**Result:** All 7 tests in `test_beauty_admin_crm.py` pass. No `/tmp` approach remains in production code or tests.